### PR TITLE
Add docker initial

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,23 @@
+## The token in `.npmrc` should never end up in the Docker image
+*/.npmrc
+
+# Log files
+*.log
+*.err
+*.log*
+
+# Generated files
+**/dist/
+**/tmp/
+**/node_modules/
+**/build/
+**/coverage/
+
+# Version control files
+.git
+
+# Docker files
+.dockerignore
+docker-compose.yml
+docker-compose.*.yml
+Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,25 @@
+# stage1 - build react app first 
+FROM node:14-alpine as build
+WORKDIR /app
+ENV PATH /app/node_modules/.bin:$PATH
+
+COPY ./package.json /app/
+COPY ./yarn.lock /app/
+COPY ./lerna.json /app/
+COPY ./packages/app/package.json /app/packages/app/
+COPY ./packages/authentication/package.json /app/packages/authentication/
+COPY ./packages/localization/package.json /app/packages/localization/
+COPY ./packages/user-interface/package.json /app/packages/user-interface/
+
+RUN yarn global add lerna && yarn run bootstrap
+
+COPY . /app
+RUN yarn run build:dev
+
+# stage 2 - build the final image and copy the react build files
+FROM nginx:1.21.1-alpine
+COPY --from=build /app/packages/app/build /usr/share/nginx/html
+RUN rm /etc/nginx/conf.d/default.conf
+COPY nginx/nginx.conf /etc/nginx/conf.d
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,14 @@
+version: '3.7'
+
+services:
+
+  frontend:
+    container_name: nl-portal-dev
+    build:
+      context: .
+      dockerfile: Dockerfile
+    volumes:
+      - '.:/app'
+      - '/app/node_modules'
+    ports:
+      - 3000:80

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,0 +1,21 @@
+server {
+
+  listen 80;
+
+  location / {
+    root   /usr/share/nginx/html;
+    index  index.html index.htm;
+
+    # to redirect all the requests to index.html, 
+    # useful when you are using react-router
+
+    try_files $uri /index.html; 
+  }
+
+  error_page   500 502 503 504  /50x.html;
+
+  location = /50x.html {
+    root   /usr/share/nginx/html;
+  }
+
+}

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "scripts": {
     "bootstrap": "lerna bootstrap",
     "build": "lerna run build",
+    "build:dev": "lerna run build:dev",
     "build:staging": "lerna run build:staging",
     "kill-ports": "kill-port --port 3000",
     "start": "npm run kill-ports && lerna run start --parallel",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -25,6 +25,7 @@
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",
+    "build:dev": "env-cmd -f .env.development react-scripts build",
     "build:staging": "env-cmd -f .env.staging react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject"

--- a/packages/authentication/package.json
+++ b/packages/authentication/package.json
@@ -12,6 +12,7 @@
   },
   "scripts": {
     "build": "microbundle-crl --format modern,cjs",
+    "build:dev": "yarn run build",
     "build:staging": "yarn run build",
     "start": "microbundle-crl watch --no-compress --no-sourcemap --format modern,cjs",
     "prepare": "run-s build",

--- a/packages/localization/package.json
+++ b/packages/localization/package.json
@@ -12,6 +12,7 @@
   },
   "scripts": {
     "build": "microbundle-crl --format modern,cjs",
+    "build:dev": "yarn run build",
     "build:staging": "yarn run build",
     "start": "microbundle-crl watch --no-compress --no-sourcemap --format modern,cjs",
     "prepare": "run-s build",

--- a/packages/user-interface/package.json
+++ b/packages/user-interface/package.json
@@ -12,6 +12,7 @@
   },
   "scripts": {
     "build": "microbundle-crl --format modern,cjs",
+    "build:dev": "yarn run build",
     "build:staging": "yarn run build",
     "start": "microbundle-crl watch --no-compress --no-sourcemap --format modern,cjs",
     "prepare": "run-s build",


### PR DESCRIPTION
Rework has to be done later. For example: 
- The default command used for yarn in dockerfile is: yarn run build:dev. This is needed, because the env.development has settings to use keycloak.
- The docker-compose will run the build
- It needs to be pushed to a registry from Github Actions
- Update readme

For the reviewers:
This has been tested on a windows 10 OS. Please test it on a non-windows OS.

To build with dockerfile:
- DOCKER_BUILDKIT=0 docker build -f Dockerfile -t nl-portal-image:latest .
or
- docker build -f Dockerfile -t nl-portal-image:latest .

To build and run with docker compose
- docker compose up (this will use docker cli)
or
- docker-compose up

Open browser and go to: http://localhost:3000