### PR TITLE
feat: show current cases

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -31,7 +31,8 @@
     "import/prefer-default-export": "off",
     "react/prop-types": "off",
     "no-unused-vars": "off",
-    "@typescript-eslint/no-unused-vars": ["error"]
+    "@typescript-eslint/no-unused-vars": ["error"],
+    "prettier/prettier": ["error", {"endOfLine": "auto"}, {"usePrettierrc": true}]
   },
   "settings": {
     "import/resolver": {

--- a/packages/app/src/components/app/app.tsx
+++ b/packages/app/src/components/app/app.tsx
@@ -9,6 +9,7 @@ import {
   OverviewPage,
   PortalPage,
   ThemesPage,
+  CasePage,
 } from '@nl-portal/user-interface';
 import {KeycloakWrapper} from '@nl-portal/authentication';
 import {LocalizationProvider} from '@nl-portal/localization';
@@ -40,6 +41,15 @@ const pages: Array<PortalPage> = [
     path: '/zaken',
     titleTranslationKey: 'cases',
     showInMenu: true,
+    children: [
+      {
+        icon: <ArchiveIcon />,
+        pageComponent: CasePage,
+        path: '/zaak',
+        titleTranslationKey: 'cases',
+        showInMenu: true,
+      },
+    ],
   },
   {
     icon: <DocumentIcon />,

--- a/packages/app/src/components/app/app.tsx
+++ b/packages/app/src/components/app/app.tsx
@@ -20,7 +20,7 @@ import Facet from '../../assets/facet.png';
 const pages: Array<PortalPage> = [
   {
     icon: <GridIcon />,
-    pageComponent: OverviewPage(),
+    pageComponent: OverviewPage,
     path: '/',
     titleTranslationKey: 'overview',
     showInMenu: true,
@@ -28,7 +28,7 @@ const pages: Array<PortalPage> = [
   },
   {
     icon: <InboxIcon />,
-    pageComponent: NotificationsPage(),
+    pageComponent: NotificationsPage,
     path: '/berichten',
     titleTranslationKey: 'notifications',
     showInMenu: true,
@@ -36,14 +36,14 @@ const pages: Array<PortalPage> = [
   },
   {
     icon: <ArchiveIcon />,
-    pageComponent: CasesPage(),
+    pageComponent: CasesPage,
     path: '/zaken',
     titleTranslationKey: 'cases',
     showInMenu: true,
   },
   {
     icon: <DocumentIcon />,
-    pageComponent: ThemesPage(),
+    pageComponent: ThemesPage,
     path: '/themas',
     titleTranslationKey: 'themes',
     showInMenu: true,

--- a/packages/app/src/components/app/app.tsx
+++ b/packages/app/src/components/app/app.tsx
@@ -21,7 +21,7 @@ import Facet from '../../assets/facet.png';
 const pages: Array<PortalPage> = [
   {
     icon: <GridIcon />,
-    pageComponent: OverviewPage,
+    pageComponent: <OverviewPage />,
     path: '/',
     titleTranslationKey: 'overview',
     showInMenu: true,
@@ -29,7 +29,7 @@ const pages: Array<PortalPage> = [
   },
   {
     icon: <InboxIcon />,
-    pageComponent: NotificationsPage,
+    pageComponent: <NotificationsPage />,
     path: '/berichten',
     titleTranslationKey: 'notifications',
     showInMenu: true,
@@ -37,14 +37,14 @@ const pages: Array<PortalPage> = [
   },
   {
     icon: <ArchiveIcon />,
-    pageComponent: CasesPage,
+    pageComponent: <CasesPage />,
     path: '/zaken',
     titleTranslationKey: 'cases',
     showInMenu: true,
     children: [
       {
         icon: <ArchiveIcon />,
-        pageComponent: CasePage,
+        pageComponent: <CasePage />,
         path: '/zaak',
         titleTranslationKey: 'cases',
         showInMenu: true,
@@ -53,7 +53,7 @@ const pages: Array<PortalPage> = [
   },
   {
     icon: <DocumentIcon />,
-    pageComponent: ThemesPage,
+    pageComponent: <ThemesPage />,
     path: '/themas',
     titleTranslationKey: 'themes',
     showInMenu: true,

--- a/packages/app/src/i18n/custom-messages/en-gb.ts
+++ b/packages/app/src/i18n/custom-messages/en-gb.ts
@@ -3,5 +3,9 @@ import {DEFAULT_LOCALES, Messages} from '@nl-portal/localization';
 export const EN_GB_MESSAGES: Messages = {
   [DEFAULT_LOCALES.ENGLISH]: {
     'app.appName': 'MijnDenHaag',
+    'case.parking-permit.title': 'Application for parking permit',
+    'case.holiday-rental.title': 'Application for holiday rental',
+    'case.welfare.title': 'Application for welfare',
+    'case.relocation.title': 'Relocation',
   },
 };

--- a/packages/app/src/i18n/custom-messages/nl-nl.ts
+++ b/packages/app/src/i18n/custom-messages/nl-nl.ts
@@ -3,5 +3,9 @@ import {DEFAULT_LOCALES, Messages} from '@nl-portal/localization';
 export const NL_NL_MESSAGES: Messages = {
   [DEFAULT_LOCALES.DUTCH]: {
     'app.appName': 'MijnDenHaag',
+    'case.parking-permit.title': 'Aanvraag parkeervergunning',
+    'case.holiday-rental.title': 'Aanvraag vakantieverhuur',
+    'case.welfare.title': 'Aanvraag bijstandsuitkering',
+    'case.relocation.title': 'Verhuizing',
   },
 };

--- a/packages/app/src/styles/nl-portal-design-tokens.css
+++ b/packages/app/src/styles/nl-portal-design-tokens.css
@@ -9,6 +9,8 @@
   --nlportal-space-inline-xl: var(--denhaag-space-inline-xl);
   --nlportal-space-inline-lg: var(--denhaag-space-inline-lg);
   --nlportal-space-inline-md: var(--denhaag-space-inline-md);
+  --nlportal-z-index-header: 100;
+  --nlportal-z-index-menu: 200;
   --nlportal-max-page-width: 1024px;
   --nlportal-header-height: 72px;
   --nlportal-header-height-large: 85px;

--- a/packages/localization/src/i18n/messages/en-gb.ts
+++ b/packages/localization/src/i18n/messages/en-gb.ts
@@ -13,5 +13,6 @@ export const EN_GB_MESSAGES: Messages = {
     'header.welcome': 'Welcome {userName}',
     'header.menuButton': 'Menu',
     'menu.close': 'Close menu',
+    'titles.completedCases': 'Closed cases',
   },
 };

--- a/packages/localization/src/i18n/messages/nl-nl.ts
+++ b/packages/localization/src/i18n/messages/nl-nl.ts
@@ -13,5 +13,6 @@ export const NL_NL_MESSAGES: Messages = {
     'header.welcome': 'Welkom {userName}',
     'header.menuButton': 'Menu',
     'menu.close': 'Menu sluiten',
+    'titles.completedCases': 'Afgeronde zaken',
   },
 };

--- a/packages/user-interface/package.json
+++ b/packages/user-interface/package.json
@@ -50,7 +50,7 @@
     "dist"
   ],
   "dependencies": {
-    "@gemeente-denhaag/denhaag-component-library": "0.2.3-alpha.19",
+    "@gemeente-denhaag/denhaag-component-library": "0.2.3-alpha.21",
     "@gemeente-denhaag/icons": "^0.2.3-alpha.16",
     "@nl-portal/localization": "0.1.0",
     "@react-keycloak/web": "^3.4.0",

--- a/packages/user-interface/src/components/current-page-indicator/current-page-indicator.module.scss
+++ b/packages/user-interface/src/components/current-page-indicator/current-page-indicator.module.scss
@@ -14,6 +14,7 @@
   padding-block-start: var(--nlportal-space-block-md, 1rem);
   padding-block-end: var(--nlportal-space-block-md, 1rem);
   height: var(--nl-portal-current-page-indicator-height, 56px);
+  z-index: var(--nlportal-z-index-header, 100);
 
   @include breakpoint(tablet) {
     display: none;

--- a/packages/user-interface/src/components/current-page-indicator/current-page-indicator.module.scss
+++ b/packages/user-interface/src/components/current-page-indicator/current-page-indicator.module.scss
@@ -26,6 +26,7 @@
 }
 
 .current-page-indicator--header-fixed {
+  transition: top 0.08s ease-out;
   position: fixed;
 }
 

--- a/packages/user-interface/src/components/header/header.module.scss
+++ b/packages/user-interface/src/components/header/header.module.scss
@@ -8,6 +8,7 @@
   top: 0;
   left: 0;
   transform: translateY(0);
+  z-index: var(--nlportal-z-index-header, 100);
 
   @include breakpoint(tablet) {
     position: fixed;

--- a/packages/user-interface/src/components/header/header.module.scss
+++ b/packages/user-interface/src/components/header/header.module.scss
@@ -17,6 +17,7 @@
 
 .header-wrapper--fixed {
   position: fixed;
+  transition: transform 0.08s ease-out;
 }
 
 .header-wrapper--hidden {

--- a/packages/user-interface/src/components/layout/layout.module.scss
+++ b/packages/user-interface/src/components/layout/layout.module.scss
@@ -42,6 +42,7 @@
 
 .page-container__menu {
   width: 0;
+  z-index: var(--nlportal-z-index-menu, 200);
 
   @include breakpoint(tablet) {
     width: var(--nlportal-desktop-menu-width, 230px);

--- a/packages/user-interface/src/components/layout/layout.tsx
+++ b/packages/user-interface/src/components/layout/layout.tsx
@@ -63,7 +63,7 @@ const Layout: FC<LayoutProps> = ({headerLogo, headerFacet, pages}) => {
                 <Switch>
                   {pages.map(page => (
                     <Route exact key={page.path} path={page.path}>
-                      <Page page={page}>{page.pageComponent}</Page>
+                      <Page page={page}>{page.pageComponent()}</Page>
                     </Route>
                   ))}
                   <Route render={() => <Redirect to="/" />} />

--- a/packages/user-interface/src/components/layout/layout.tsx
+++ b/packages/user-interface/src/components/layout/layout.tsx
@@ -65,12 +65,12 @@ const Layout: FC<LayoutProps> = ({headerLogo, headerFacet, pages}) => {
                     (accumulator, page) => [
                       ...accumulator,
                       <Route exact key={page.path} path={page.path}>
-                        <Page page={page}>{page.pageComponent()}</Page>
+                        <Page page={page}>{page.pageComponent}</Page>
                       </Route>,
                       ...(page.children
                         ? page.children.map(childPage => (
                             <Route key={childPage.path} path={`${page.path}${childPage.path}`}>
-                              <Page page={childPage}>{childPage.pageComponent()}</Page>
+                              <Page page={childPage}>{childPage.pageComponent}</Page>
                             </Route>
                           ))
                         : []),

--- a/packages/user-interface/src/components/layout/layout.tsx
+++ b/packages/user-interface/src/components/layout/layout.tsx
@@ -61,11 +61,22 @@ const Layout: FC<LayoutProps> = ({headerLogo, headerFacet, pages}) => {
               </div>
               <div className={styles['page-container__page']}>
                 <Switch>
-                  {pages.map(page => (
-                    <Route exact key={page.path} path={page.path}>
-                      <Page page={page}>{page.pageComponent()}</Page>
-                    </Route>
-                  ))}
+                  {pages.reduce(
+                    (accumulator, page) => [
+                      ...accumulator,
+                      <Route exact key={page.path} path={page.path}>
+                        <Page page={page}>{page.pageComponent()}</Page>
+                      </Route>,
+                      ...(page.children
+                        ? page.children.map(childPage => (
+                            <Route key={childPage.path} path={`${page.path}${childPage.path}`}>
+                              <Page page={childPage}>{childPage.pageComponent()}</Page>
+                            </Route>
+                          ))
+                        : []),
+                    ],
+                    []
+                  )}
                   <Route render={() => <Redirect to="/" />} />
                 </Switch>
               </div>

--- a/packages/user-interface/src/components/menu-item/menu-item.tsx
+++ b/packages/user-interface/src/components/menu-item/menu-item.tsx
@@ -17,6 +17,13 @@ const MenuItem: FC<MenuItemProps> = ({item}) => {
   const {hrefLang} = useContext(LocaleContext);
   const {hideMenu, messagesCount} = useContext(LayoutContext);
   const location = useLocation();
+  const getBasePath = (url: string) => {
+    const splitUrl = url.split('/');
+    if (splitUrl.length > 0) {
+      return splitUrl[1];
+    }
+    return url;
+  };
 
   return (
     <Link
@@ -24,7 +31,7 @@ const MenuItem: FC<MenuItemProps> = ({item}) => {
       onClick={hideMenu}
       hrefLang={hrefLang}
       className={classNames('denhaag-menu-button', styles['denhaag-menu-button--flex'], {
-        'denhaag-menu-button--active': location.pathname === item.path,
+        'denhaag-menu-button--active': getBasePath(location.pathname) === getBasePath(item.path),
       })}
     >
       {item.icon && <div className={styles['denhaag-menu-button__icon']}>{item.icon}</div>}

--- a/packages/user-interface/src/hooks/index.ts
+++ b/packages/user-interface/src/hooks/index.ts
@@ -1,1 +1,2 @@
 export * from './use-document-scroll-throttled';
+export * from './use-media-query';

--- a/packages/user-interface/src/hooks/use-media-query.ts
+++ b/packages/user-interface/src/hooks/use-media-query.ts
@@ -1,0 +1,19 @@
+import {useState, useEffect} from 'react';
+
+const useMediaQuery = (query: string) => {
+  const [matches, setMatches] = useState(false);
+
+  useEffect(() => {
+    const media = window.matchMedia(query);
+    if (media.matches !== matches) {
+      setMatches(media.matches);
+    }
+    const listener = () => setMatches(media.matches);
+    window.addEventListener('resize', listener);
+    return () => window.removeEventListener('resize', listener);
+  }, [matches, query]);
+
+  return matches;
+};
+
+export {useMediaQuery};

--- a/packages/user-interface/src/interfaces/index.ts
+++ b/packages/user-interface/src/interfaces/index.ts
@@ -1,1 +1,2 @@
 export * from './portal-page';
+export * from './portal-case';

--- a/packages/user-interface/src/interfaces/portal-case.ts
+++ b/packages/user-interface/src/interfaces/portal-case.ts
@@ -1,0 +1,7 @@
+export interface PortalCase {
+  id: string;
+  type: string;
+  createdOn: Date;
+  completed?: boolean;
+  subtitle?: string;
+}

--- a/packages/user-interface/src/interfaces/portal-page.ts
+++ b/packages/user-interface/src/interfaces/portal-page.ts
@@ -3,7 +3,7 @@ import {ReactElement} from 'react';
 export interface PortalPage {
   path: string;
   titleTranslationKey: string;
-  pageComponent: () => ReactElement;
+  pageComponent: ReactElement;
   isHome?: boolean;
   showInMenu?: boolean;
   showMessagesCount?: boolean;

--- a/packages/user-interface/src/interfaces/portal-page.ts
+++ b/packages/user-interface/src/interfaces/portal-page.ts
@@ -3,7 +3,7 @@ import {ReactElement} from 'react';
 export interface PortalPage {
   path: string;
   titleTranslationKey: string;
-  pageComponent: ReactElement;
+  pageComponent: () => ReactElement;
   isHome?: boolean;
   showInMenu?: boolean;
   showMessagesCount?: boolean;

--- a/packages/user-interface/src/pages/case/case-page.test.tsx
+++ b/packages/user-interface/src/pages/case/case-page.test.tsx
@@ -1,0 +1,7 @@
+import {CasePage} from './case-page';
+
+describe('Case', () => {
+  it('is truthy', () => {
+    expect(CasePage).toBeTruthy();
+  });
+});

--- a/packages/user-interface/src/pages/case/case-page.tsx
+++ b/packages/user-interface/src/pages/case/case-page.tsx
@@ -1,0 +1,4 @@
+import * as React from 'react';
+
+const CasePage = () => <div>case</div>;
+export {CasePage};

--- a/packages/user-interface/src/pages/case/index.ts
+++ b/packages/user-interface/src/pages/case/index.ts
@@ -1,0 +1,1 @@
+export * from './case-page';

--- a/packages/user-interface/src/pages/cases/cases-page-mock.ts
+++ b/packages/user-interface/src/pages/cases/cases-page-mock.ts
@@ -1,0 +1,19 @@
+import {PortalCase} from '../../interfaces';
+
+export const mockCases: Array<PortalCase> = [
+  {
+    createdOn: new Date(2021, 1, 1),
+    id: 'xxx',
+    type: 'parking-permit',
+  },
+  {
+    createdOn: new Date(2021, 1, 3),
+    id: 'xxx',
+    type: 'holiday-rental',
+  },
+  {
+    createdOn: new Date(2021, 1, 5),
+    id: 'xxx',
+    type: 'parking-permit',
+  },
+];

--- a/packages/user-interface/src/pages/cases/cases-page-mock.ts
+++ b/packages/user-interface/src/pages/cases/cases-page-mock.ts
@@ -3,17 +3,17 @@ import {PortalCase} from '../../interfaces';
 export const mockCases: Array<PortalCase> = [
   {
     createdOn: new Date(2021, 1, 1),
-    id: 'xxx',
+    id: '1',
     type: 'parking-permit',
   },
   {
     createdOn: new Date(2021, 1, 3),
-    id: 'xxx',
+    id: '2',
     type: 'holiday-rental',
   },
   {
     createdOn: new Date(2021, 1, 5),
-    id: 'xxx',
+    id: '3',
     type: 'parking-permit',
   },
 ];

--- a/packages/user-interface/src/pages/cases/cases-page-mock.ts
+++ b/packages/user-interface/src/pages/cases/cases-page-mock.ts
@@ -16,4 +16,40 @@ export const mockCases: Array<PortalCase> = [
     id: '3',
     type: 'parking-permit',
   },
+  {
+    createdOn: new Date(2021, 1, 1),
+    id: '1',
+    type: 'parking-permit',
+    completed: true,
+  },
+  {
+    createdOn: new Date(2021, 1, 3),
+    id: '2',
+    type: 'holiday-rental',
+    completed: true,
+  },
+  {
+    createdOn: new Date(2021, 1, 5),
+    id: '3',
+    type: 'parking-permit',
+    completed: true,
+  },
+  {
+    createdOn: new Date(2021, 1, 6),
+    id: '4',
+    type: 'parking-permit',
+    completed: true,
+  },
+  {
+    createdOn: new Date(2021, 1, 9),
+    id: '5',
+    type: 'holiday-rental',
+    completed: true,
+  },
+  {
+    createdOn: new Date(2021, 1, 11),
+    id: '6',
+    type: 'parking-permit',
+    completed: true,
+  },
 ];

--- a/packages/user-interface/src/pages/cases/cases-page-mock.ts
+++ b/packages/user-interface/src/pages/cases/cases-page-mock.ts
@@ -10,6 +10,7 @@ export const mockCases: Array<PortalCase> = [
     createdOn: new Date(2021, 1, 3),
     id: '2',
     type: 'holiday-rental',
+    subtitle: 'Dierenselaan 88',
   },
   {
     createdOn: new Date(2021, 1, 5),

--- a/packages/user-interface/src/pages/cases/cases-page.module.scss
+++ b/packages/user-interface/src/pages/cases/cases-page.module.scss
@@ -1,0 +1,15 @@
+@import '../../styles/mixins';
+
+.cases {
+  display: flex;
+  flex-direction: column;
+  --denhaag-card-width: 100%;
+}
+
+.cases__header {
+  margin-block-end: var(--nlportal-space-block-xl, 1.5rem);
+
+  @include breakpoint(tablet) {
+    margin-block-end: var(--nlportal-space-block-2xl, 2rem);
+  }
+}

--- a/packages/user-interface/src/pages/cases/cases-page.module.scss
+++ b/packages/user-interface/src/pages/cases/cases-page.module.scss
@@ -5,7 +5,7 @@
   flex-direction: column;
   --denhaag-card-width: 100%;
 
-  div[role=tabpanel] {
+  div[role='tabpanel'] {
     padding: 0;
     padding-block-start: var(--nlportal-space-block-2xl, 2rem);
   }

--- a/packages/user-interface/src/pages/cases/cases-page.module.scss
+++ b/packages/user-interface/src/pages/cases/cases-page.module.scss
@@ -4,6 +4,11 @@
   display: flex;
   flex-direction: column;
   --denhaag-card-width: 100%;
+
+  div[role=tabpanel] {
+    padding: 0;
+    padding-block-start: var(--nlportal-space-block-2xl, 2rem);
+  }
 }
 
 .cases__header {

--- a/packages/user-interface/src/pages/cases/cases-page.module.scss
+++ b/packages/user-interface/src/pages/cases/cases-page.module.scss
@@ -13,3 +13,21 @@
     margin-block-end: var(--nlportal-space-block-2xl, 2rem);
   }
 }
+
+.cases__cards {
+  display: flex;
+  flex-direction: column;
+
+  @include breakpoint(desktop) {
+    flex-flow: row wrap;
+    justify-content: space-between;
+  }
+}
+
+.cases__card {
+  margin-block-end: var(--nlportal-space-block-xl, 1.5rem);
+
+  @include breakpoint(desktop) {
+    width: calc(50% - var(--nlportal-space-inline-md, 1rem));
+  }
+}

--- a/packages/user-interface/src/pages/cases/cases-page.tsx
+++ b/packages/user-interface/src/pages/cases/cases-page.tsx
@@ -1,11 +1,37 @@
 import * as React from 'react';
-import {Heading2, Card} from '@gemeente-denhaag/denhaag-component-library';
+import {
+  Heading2,
+  Card,
+  Tabs,
+  Tab,
+  TabContext,
+  TabPanel,
+} from '@gemeente-denhaag/denhaag-component-library';
 import {FormattedMessage, useIntl} from 'react-intl';
+import {useState} from 'react';
 import styles from './cases-page.module.scss';
 import {mockCases} from './cases-page-mock';
+import {useMediaQuery} from '../../hooks';
 
 const CasesPage = () => {
+  const [tabNumber, setTabNumber] = useState(0);
   const intl = useIntl();
+  const isTablet = useMediaQuery('(min-width: 768px)');
+
+  const getCaseCards = (completed: boolean) =>
+    mockCases
+      .filter(mockCase => (completed ? mockCase.completed : !mockCase.completed))
+      .sort((a, b) => (b.createdOn as any) - (a.createdOn as any))
+      .map(mockCase => (
+        <div className={styles.cases__card} key={mockCase.id}>
+          <Card
+            variant="case"
+            title={intl.formatMessage({id: `case.${mockCase.type}.title`})}
+            date={mockCase.createdOn}
+            href="./"
+          />
+        </div>
+      ));
 
   return (
     <section className={styles.cases}>
@@ -14,18 +40,24 @@ const CasesPage = () => {
           <FormattedMessage id="pageTitles.cases" />
         </Heading2>
       </header>
-      <div className={styles.cases__cards}>
-        {mockCases.map(mockCase => (
-          <div className={styles.cases__card} key={mockCase.id}>
-            <Card
-              variant="case"
-              title={intl.formatMessage({id: `case.${mockCase.type}.title`})}
-              date={mockCase.createdOn}
-              href="./"
-            />
-          </div>
-        ))}
-      </div>
+      <TabContext value={tabNumber.toString()}>
+        <Tabs
+          variant={isTablet ? 'standard' : 'fullWidth'}
+          value={tabNumber}
+          onChange={(_event: React.ChangeEvent<unknown>, newValue: number) => {
+            setTabNumber(newValue);
+          }}
+        >
+          <Tab label={intl.formatMessage({id: 'pageTitles.cases'})} value={0} />
+          <Tab label={intl.formatMessage({id: 'titles.completedCases'})} value={1} />
+        </Tabs>
+        <TabPanel value="0">
+          <div className={styles.cases__cards}>{getCaseCards(false)}</div>
+        </TabPanel>
+        <TabPanel value="1">
+          <div className={styles.cases__cards}>{getCaseCards(true)}</div>
+        </TabPanel>
+      </TabContext>
     </section>
   );
 };

--- a/packages/user-interface/src/pages/cases/cases-page.tsx
+++ b/packages/user-interface/src/pages/cases/cases-page.tsx
@@ -27,6 +27,7 @@ const CasesPage = () => {
           <Card
             variant="case"
             title={intl.formatMessage({id: `case.${mockCase.type}.title`})}
+            subTitle={mockCase.subtitle}
             date={mockCase.createdOn}
             href="#"
           />

--- a/packages/user-interface/src/pages/cases/cases-page.tsx
+++ b/packages/user-interface/src/pages/cases/cases-page.tsx
@@ -1,4 +1,16 @@
 import * as React from 'react';
+import {Heading2, Card} from '@gemeente-denhaag/denhaag-component-library';
+import {FormattedMessage} from 'react-intl';
+import styles from './cases-page.module.scss';
 
-const CasesPage = () => <div>cases</div>;
+const CasesPage = () => (
+  <section className={styles.cases}>
+    <header className={styles.cases__header}>
+      <Heading2>
+        <FormattedMessage id="pageTitles.cases" />
+      </Heading2>
+    </header>
+    <Card variant="case" title="test" date={new Date()} href="./" />
+  </section>
+);
 export {CasesPage};

--- a/packages/user-interface/src/pages/cases/cases-page.tsx
+++ b/packages/user-interface/src/pages/cases/cases-page.tsx
@@ -9,6 +9,7 @@ import {
 } from '@gemeente-denhaag/denhaag-component-library';
 import {FormattedMessage, useIntl} from 'react-intl';
 import {useState} from 'react';
+import {useHistory} from 'react-router-dom';
 import styles from './cases-page.module.scss';
 import {mockCases} from './cases-page-mock';
 import {useMediaQuery} from '../../hooks';
@@ -17,6 +18,13 @@ const CasesPage = () => {
   const [tabNumber, setTabNumber] = useState(0);
   const intl = useIntl();
   const isTablet = useMediaQuery('(min-width: 768px)');
+  const history = useHistory();
+
+  const handleCardClick = (event: any) => {
+    event.stopPropagation();
+    console.log('hi');
+    history.push('/zaken');
+  };
 
   const getCaseCards = (completed: boolean) =>
     mockCases
@@ -29,7 +37,7 @@ const CasesPage = () => {
             title={intl.formatMessage({id: `case.${mockCase.type}.title`})}
             subTitle={mockCase.subtitle}
             date={mockCase.createdOn}
-            href="#"
+            onClick={handleCardClick}
           />
         </div>
       ));

--- a/packages/user-interface/src/pages/cases/cases-page.tsx
+++ b/packages/user-interface/src/pages/cases/cases-page.tsx
@@ -28,7 +28,7 @@ const CasesPage = () => {
             variant="case"
             title={intl.formatMessage({id: `case.${mockCase.type}.title`})}
             date={mockCase.createdOn}
-            href="./"
+            href="#"
           />
         </div>
       ));
@@ -61,4 +61,5 @@ const CasesPage = () => {
     </section>
   );
 };
+
 export {CasesPage};

--- a/packages/user-interface/src/pages/cases/cases-page.tsx
+++ b/packages/user-interface/src/pages/cases/cases-page.tsx
@@ -18,13 +18,8 @@ const CasesPage = () => {
   const [tabNumber, setTabNumber] = useState(0);
   const intl = useIntl();
   const isTablet = useMediaQuery('(min-width: 768px)');
+  const caseUrl = '/zaken/zaak';
   const history = useHistory();
-
-  const handleCardClick = (event: any) => {
-    event.stopPropagation();
-    console.log('hi');
-    history.push('/zaken');
-  };
 
   const getCaseCards = (completed: boolean) =>
     mockCases
@@ -37,7 +32,8 @@ const CasesPage = () => {
             title={intl.formatMessage({id: `case.${mockCase.type}.title`})}
             subTitle={mockCase.subtitle}
             date={mockCase.createdOn}
-            onClick={handleCardClick}
+            href={caseUrl}
+            onClick={() => history.push(caseUrl)}
           />
         </div>
       ));

--- a/packages/user-interface/src/pages/cases/cases-page.tsx
+++ b/packages/user-interface/src/pages/cases/cases-page.tsx
@@ -1,23 +1,32 @@
 import * as React from 'react';
 import {Heading2, Card} from '@gemeente-denhaag/denhaag-component-library';
-import {FormattedMessage} from 'react-intl';
+import {FormattedMessage, useIntl} from 'react-intl';
 import styles from './cases-page.module.scss';
 import {mockCases} from './cases-page-mock';
 
-const CasesPage = () => (
-  <section className={styles.cases}>
-    <header className={styles.cases__header}>
-      <Heading2>
-        <FormattedMessage id="pageTitles.cases" />
-      </Heading2>
-    </header>
-    <div className={styles.cases__cards}>
-      {mockCases.map(mockCase => (
-        <div className={styles.cases__card}>
-          <Card variant="case" title={mockCase.type} date={mockCase.createdOn} href="./" />
-        </div>
-      ))}
-    </div>
-  </section>
-);
+const CasesPage = () => {
+  const intl = useIntl();
+
+  return (
+    <section className={styles.cases}>
+      <header className={styles.cases__header}>
+        <Heading2>
+          <FormattedMessage id="pageTitles.cases" />
+        </Heading2>
+      </header>
+      <div className={styles.cases__cards}>
+        {mockCases.map(mockCase => (
+          <div className={styles.cases__card} key={mockCase.id}>
+            <Card
+              variant="case"
+              title={intl.formatMessage({id: `case.${mockCase.type}.title`})}
+              date={mockCase.createdOn}
+              href="./"
+            />
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+};
 export {CasesPage};

--- a/packages/user-interface/src/pages/cases/cases-page.tsx
+++ b/packages/user-interface/src/pages/cases/cases-page.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import {Heading2, Card} from '@gemeente-denhaag/denhaag-component-library';
 import {FormattedMessage} from 'react-intl';
 import styles from './cases-page.module.scss';
+import {mockCases} from './cases-page-mock';
 
 const CasesPage = () => (
   <section className={styles.cases}>
@@ -10,7 +11,13 @@ const CasesPage = () => (
         <FormattedMessage id="pageTitles.cases" />
       </Heading2>
     </header>
-    <Card variant="case" title="test" date={new Date()} href="./" />
+    <div className={styles.cases__cards}>
+      {mockCases.map(mockCase => (
+        <div className={styles.cases__card}>
+          <Card variant="case" title={mockCase.type} date={mockCase.createdOn} href="./" />
+        </div>
+      ))}
+    </div>
   </section>
 );
 export {CasesPage};

--- a/packages/user-interface/src/pages/index.ts
+++ b/packages/user-interface/src/pages/index.ts
@@ -2,3 +2,4 @@ export * from './overview';
 export * from './cases';
 export * from './notifications';
 export * from './themes';
+export * from './case';

--- a/packages/user-interface/src/styles/_definitions.scss
+++ b/packages/user-interface/src/styles/_definitions.scss
@@ -1,3 +1,4 @@
 $breakpoints: (
   tablet: 768px,
+  desktop: 992px
 );

--- a/packages/user-interface/src/styles/_definitions.scss
+++ b/packages/user-interface/src/styles/_definitions.scss
@@ -1,4 +1,4 @@
 $breakpoints: (
   tablet: 768px,
-  desktop: 992px
+  desktop: 992px,
 );

--- a/yarn.lock
+++ b/yarn.lock
@@ -1372,51 +1372,51 @@
     intl-messageformat "9.9.1"
     tslib "^2.1.0"
 
-"@gemeente-denhaag/accordion@^0.2.3-alpha.7":
-  version "0.2.3-alpha.7"
-  resolved "https://registry.yarnpkg.com/@gemeente-denhaag/accordion/-/accordion-0.2.3-alpha.7.tgz#931c56a09d3324d9335bf63f16f0352ce20bbb4f"
-  integrity sha512-+pPaYUIjN4vALaxpFH8gPe/6oK1Vj7I2Thil4nwhMpaMptu6R4ysEsEIkU5LbMn065omjcDch82qNeYgE9YXWA==
+"@gemeente-denhaag/accordion@^0.2.3-alpha.21":
+  version "0.2.3-alpha.21"
+  resolved "https://registry.yarnpkg.com/@gemeente-denhaag/accordion/-/accordion-0.2.3-alpha.21.tgz#21d79cfb982633d1b2922d3472db8e116d061afd"
+  integrity sha512-dQCyuRWIcmvxWVBOE/UQzjLTzoUfYSprLkVHBVG8bQ4HGnEeiXcxLCCYPpZn6Fsmgo4WdO7Pt8AsyobMHNcSpA==
   dependencies:
-    "@gemeente-denhaag/baseprops" "^0.2.3-alpha.7"
+    "@gemeente-denhaag/baseprops" "^0.2.3-alpha.21"
     "@material-ui/core" "^4.11.0"
 
-"@gemeente-denhaag/appbar@^0.2.3-alpha.7":
-  version "0.2.3-alpha.7"
-  resolved "https://registry.yarnpkg.com/@gemeente-denhaag/appbar/-/appbar-0.2.3-alpha.7.tgz#12a8fb873bce761fe5a5cd0cd29f401397ab19b0"
-  integrity sha512-pPK0EstQIlYhm6Se02e4kxi1siwNlQ6Fjj8nzAcIeeFcAMzRp/YFD9E/7QooPrz1jQ3OuBKjnf1h4SpYu0wnkQ==
+"@gemeente-denhaag/appbar@^0.2.3-alpha.21":
+  version "0.2.3-alpha.21"
+  resolved "https://registry.yarnpkg.com/@gemeente-denhaag/appbar/-/appbar-0.2.3-alpha.21.tgz#03af94aa2a55cac6b552ab2ffbca1330a7afba09"
+  integrity sha512-TiLkMhZWy9wvc7jkg0eq/0B9GhXu6mD6yGrIftudD96cvk07hKJDBKc5eRSFK0ep5288kKmIC4kTA3Vs3m+pXg==
   dependencies:
-    "@gemeente-denhaag/baseprops" "^0.2.3-alpha.7"
+    "@gemeente-denhaag/baseprops" "^0.2.3-alpha.21"
     "@material-ui/core" "^4.11.0"
 
-"@gemeente-denhaag/avatar@^0.2.3-alpha.7":
-  version "0.2.3-alpha.7"
-  resolved "https://registry.yarnpkg.com/@gemeente-denhaag/avatar/-/avatar-0.2.3-alpha.7.tgz#1f331e4d631f525b20ff7a0fd609456df75a1e22"
-  integrity sha512-YL1jpsFbuPG/N4zoIk3fLuaKkJ6CVDUwRRfoWSY6FbO9E9EGLu6vPbST9QqzPNNGh0/L+PwPVudJmBJBhVK/XQ==
+"@gemeente-denhaag/avatar@^0.2.3-alpha.21":
+  version "0.2.3-alpha.21"
+  resolved "https://registry.yarnpkg.com/@gemeente-denhaag/avatar/-/avatar-0.2.3-alpha.21.tgz#6fe54b077bc57cf0bb04d087b1516142b2183c3a"
+  integrity sha512-CUHU6j+w61OV4rShu9bBYFGbAMK3oYDH+P/XH9YWbwhWhK8S7p0H9QrlnKKuMeX+wTtoYumz30KHS1BftjQJyg==
   dependencies:
-    "@gemeente-denhaag/baseprops" "^0.2.3-alpha.7"
+    "@gemeente-denhaag/baseprops" "^0.2.3-alpha.21"
     "@material-ui/core" "^4.11.0"
 
-"@gemeente-denhaag/badge-counter@^0.1.1-alpha.7":
-  version "0.1.1-alpha.7"
-  resolved "https://registry.yarnpkg.com/@gemeente-denhaag/badge-counter/-/badge-counter-0.1.1-alpha.7.tgz#5f3b1ff7b9ee815ed94041e431ba40d414302fbb"
-  integrity sha512-VNMTNoFE/9rWC6XF1+JSETxHjQnO/CYFxJ/lCD2mFuSb386p0XEG5zbHU26vBeK9A9lTpn6Hc0s2ski38TrE5Q==
+"@gemeente-denhaag/badge-counter@^0.1.1-alpha.21":
+  version "0.1.1-alpha.21"
+  resolved "https://registry.yarnpkg.com/@gemeente-denhaag/badge-counter/-/badge-counter-0.1.1-alpha.21.tgz#ef6bd2aaeb02c6cfa1ce3320b226682561f3e6ba"
+  integrity sha512-DcSrK+M09GblMtcye8QtT62GtfZdzLr4aOKMjlktT1DX/S6aRfgy/NxqUp/t6XpwTn4jxLZ4J3cULmRDILwe8Q==
   dependencies:
-    "@gemeente-denhaag/basedatadisplayprops" "^0.2.3-alpha.7"
-    "@gemeente-denhaag/dotindicator" "^0.1.1-alpha.7"
+    "@gemeente-denhaag/basedatadisplayprops" "^0.2.3-alpha.21"
+    "@gemeente-denhaag/dotindicator" "^0.1.1-alpha.21"
 
-"@gemeente-denhaag/basedatadisplayprops@^0.2.3-alpha.7":
-  version "0.2.3-alpha.7"
-  resolved "https://registry.yarnpkg.com/@gemeente-denhaag/basedatadisplayprops/-/basedatadisplayprops-0.2.3-alpha.7.tgz#0245f23c8d9b9686a978a275e69c99de8cfb13a5"
-  integrity sha512-8s4eDeaLsKk33hXEEQCFjf9/EPe0w5IqEI3SC+fMThUgU7ZAbIBlqOWlZ+4aTTu/mexl/Ndsxl1Is605skghFw==
+"@gemeente-denhaag/basedatadisplayprops@^0.2.3-alpha.21":
+  version "0.2.3-alpha.21"
+  resolved "https://registry.yarnpkg.com/@gemeente-denhaag/basedatadisplayprops/-/basedatadisplayprops-0.2.3-alpha.21.tgz#863f4abab4339e365daec46c98a4371869670637"
+  integrity sha512-6DWBs0Qu90fJ4gDXKXxluM9mygwZXsdVlcpeNzol7JK6TMUdtRTL9iak0e7MjX5udt86hrbkCs/bSnLHYlEzhg==
   dependencies:
-    "@gemeente-denhaag/baseprops" "^0.2.3-alpha.7"
+    "@gemeente-denhaag/baseprops" "^0.2.3-alpha.21"
 
-"@gemeente-denhaag/baselayoutprops@^0.2.3-alpha.7":
-  version "0.2.3-alpha.7"
-  resolved "https://registry.yarnpkg.com/@gemeente-denhaag/baselayoutprops/-/baselayoutprops-0.2.3-alpha.7.tgz#b0b5497c746c8ec66a1e2837864784d607f6cbf7"
-  integrity sha512-bh3YTF2S5/dyhjVxoHesOhv7XrtEHkP4JNf3kUUtkZTAtto0555C6NbPDj39N4cAdUr5Vs2CDiZHJEL1OsnWTw==
+"@gemeente-denhaag/baselayoutprops@^0.2.3-alpha.21":
+  version "0.2.3-alpha.21"
+  resolved "https://registry.yarnpkg.com/@gemeente-denhaag/baselayoutprops/-/baselayoutprops-0.2.3-alpha.21.tgz#f1be03365dce28f498cbb482499f4789b3ebd2f7"
+  integrity sha512-aKAv4eKdKmjvhChfCvjBjVqZjm1EAkPvNxxp2aSM8k13MpPOZq2Z6r3CAyOoICXZoQuj0tDoxHbZU8IwW6Qr8g==
   dependencies:
-    "@gemeente-denhaag/baseprops" "^0.2.3-alpha.7"
+    "@gemeente-denhaag/baseprops" "^0.2.3-alpha.21"
 
 "@gemeente-denhaag/baseprops@^0.1.7":
   version "0.1.7"
@@ -1433,162 +1433,161 @@
   resolved "https://registry.yarnpkg.com/@gemeente-denhaag/baseprops/-/baseprops-0.2.3-alpha.18.tgz#7b8d6d8a38dd6eacf3f67c2497313f6ef016ffed"
   integrity sha512-1vT4TT44IJj5wgFB8EK1/sXzsRD6gW+J19dL6P3YrCGBJgg2thidEroITLococ0L6+CQZ6n5Iaccld46WXb4cQ==
 
-"@gemeente-denhaag/baseprops@^0.2.3-alpha.7":
-  version "0.2.3-alpha.7"
-  resolved "https://registry.yarnpkg.com/@gemeente-denhaag/baseprops/-/baseprops-0.2.3-alpha.7.tgz#e50aaa28fce1b7309fdaafb8e95fd2d64c629203"
-  integrity sha512-tgjW/PKMw310RX1Pd7NDXHlBdR4g0V2BPArxRPlSLEBlfN6OiimOdDMSOsA3Squ+mRret3bfVNPll12bMucFqw==
+"@gemeente-denhaag/baseprops@^0.2.3-alpha.21":
+  version "0.2.3-alpha.21"
+  resolved "https://registry.yarnpkg.com/@gemeente-denhaag/baseprops/-/baseprops-0.2.3-alpha.21.tgz#d8c11acbe91a21e40c4da440bcf035b687b0edb3"
+  integrity sha512-8VyMmy9huWuiUTbHBfERkx4vhjArU0l+tTcv5CxjIYt+My1M8gtDVYjBrrZuqulQcfed1NSHDOsassbYcrgogQ==
 
-"@gemeente-denhaag/box@^0.2.3-alpha.7":
-  version "0.2.3-alpha.7"
-  resolved "https://registry.yarnpkg.com/@gemeente-denhaag/box/-/box-0.2.3-alpha.7.tgz#8ce9f2ac5b860fa9e12a4a3c3b79e47d47fbef1c"
-  integrity sha512-9CN1kUkscMEXsK4u7Nz78Nz9P1knvYg1NRFwGIQacmR/1SAFVagknzsN3F16JigN3E54JxWa28dKN8+hctOQAA==
+"@gemeente-denhaag/box@^0.2.3-alpha.21":
+  version "0.2.3-alpha.21"
+  resolved "https://registry.yarnpkg.com/@gemeente-denhaag/box/-/box-0.2.3-alpha.21.tgz#3b29796199246146bb041da72aafd5643e001748"
+  integrity sha512-PxnS3LdOFRVyk1zPuS0ZKm3SxagGZgqApkwuEncOmyUGM8Zax/E/YMA9MO7H8BkIaZn2FBeMxplYzFrELylcNQ==
   dependencies:
-    "@gemeente-denhaag/baselayoutprops" "^0.2.3-alpha.7"
+    "@gemeente-denhaag/baselayoutprops" "^0.2.3-alpha.21"
     "@material-ui/core" "^4.11.0"
 
-"@gemeente-denhaag/button@^0.2.3-alpha.7":
-  version "0.2.3-alpha.7"
-  resolved "https://registry.yarnpkg.com/@gemeente-denhaag/button/-/button-0.2.3-alpha.7.tgz#ecea8e4e209e8faf4d5410b1675194aafd72dae4"
-  integrity sha512-YjmNsnGTjCg3KRc1aD+LR3kTGLthifafdxopuVBNcLePf++q0mHeXecghMrgd3bE8EJLTMLweb4lVLDDvihYUA==
+"@gemeente-denhaag/button@^0.2.3-alpha.21":
+  version "0.2.3-alpha.21"
+  resolved "https://registry.yarnpkg.com/@gemeente-denhaag/button/-/button-0.2.3-alpha.21.tgz#f813cdca39919d6f41d6d8cfe10774144398d8ce"
+  integrity sha512-+8AJVYZNcSM2ygE44r+UMUT1OuUnWdmI0vrSkoFnr3ajGmW7KEVCTJel3vMrCt9ZRzUOQPtJNFTqd/IPZFOJ/Q==
   dependencies:
-    "@gemeente-denhaag/baseprops" "^0.2.3-alpha.7"
+    "@gemeente-denhaag/baseprops" "^0.2.3-alpha.21"
     "@material-ui/core" "^4.11.0"
 
-"@gemeente-denhaag/card@^0.2.3-alpha.7":
-  version "0.2.3-alpha.7"
-  resolved "https://registry.yarnpkg.com/@gemeente-denhaag/card/-/card-0.2.3-alpha.7.tgz#5cb5b14961f3317dc20e0925a61103607a4565f2"
-  integrity sha512-2v4zOUjgMGyTk3nREV2/1Q+LKM6Pd0D95VPSsoF70rRedbMvgM+DivYVgM9UG6xalaxq13ZNOY22FlO0c5D2hw==
+"@gemeente-denhaag/card@^0.2.3-alpha.21":
+  version "0.2.3-alpha.21"
+  resolved "https://registry.yarnpkg.com/@gemeente-denhaag/card/-/card-0.2.3-alpha.21.tgz#5442266044e8aee093fdfe9fa8d28eeedca6feaf"
+  integrity sha512-x5AvzJm5zAcqPAZ4ANezJw38E66xSbIh3uejoW1lp4h5znghURjLlK5Q/K2Sr0UogFFHgzIatUIvn561qmOKzQ==
   dependencies:
-    "@gemeente-denhaag/baseprops" "^0.2.3-alpha.7"
-    "@gemeente-denhaag/icons" "^0.2.3-alpha.7"
+    "@gemeente-denhaag/baseprops" "^0.2.3-alpha.21"
+    "@gemeente-denhaag/icons" "^0.2.3-alpha.21"
     "@material-ui/core" "^4.11.0"
 
-"@gemeente-denhaag/checkbox@^0.2.3-alpha.7":
-  version "0.2.3-alpha.7"
-  resolved "https://registry.yarnpkg.com/@gemeente-denhaag/checkbox/-/checkbox-0.2.3-alpha.7.tgz#5906c3e9680f7aefbd686fefaae1dc97451e8cc3"
-  integrity sha512-liecBR2JGFgqMh6prC4hsAUfhDUpTYrGaOpkoPTch2e3fsZ61z17xA2DlOp6VsciSHfP4cdvfZ+JEDOuPZe4fw==
+"@gemeente-denhaag/checkbox@^0.2.3-alpha.21":
+  version "0.2.3-alpha.21"
+  resolved "https://registry.yarnpkg.com/@gemeente-denhaag/checkbox/-/checkbox-0.2.3-alpha.21.tgz#438a85c96ef9cfc786f56bf8be315a08eaf3d7d9"
+  integrity sha512-ipGOSh3lTY5DYa3oU1aN33s7w5tyGwHL7mxt9qt5mnX0WuFHEyq7+JlHcuMrl3Oy8oNfNgrvfNX2c1qg8ek4uQ==
   dependencies:
-    "@gemeente-denhaag/baseprops" "^0.2.3-alpha.7"
-    "@gemeente-denhaag/icons" "^0.2.3-alpha.7"
+    "@gemeente-denhaag/baseprops" "^0.2.3-alpha.21"
+    "@gemeente-denhaag/icons" "^0.2.3-alpha.21"
 
-"@gemeente-denhaag/container@^0.2.3-alpha.7":
-  version "0.2.3-alpha.7"
-  resolved "https://registry.yarnpkg.com/@gemeente-denhaag/container/-/container-0.2.3-alpha.7.tgz#7c514425b66510c755288f0e5addcc05ac6a17d1"
-  integrity sha512-sOp4WOzUXPfEApiF0YHIINp+eZ8I+eKRbyS1oWkv4vJ8Ks4T36n5V0+rm/wZ/oUVb9lPYcved7awE4S9p3HSWg==
+"@gemeente-denhaag/container@^0.2.3-alpha.21":
+  version "0.2.3-alpha.21"
+  resolved "https://registry.yarnpkg.com/@gemeente-denhaag/container/-/container-0.2.3-alpha.21.tgz#922442a1f28b336e26b89bfe08cd2b74ecab0b93"
+  integrity sha512-InH2EJRDLOIazBCiGqkAmmc2v8ZBEjDUvpwLY303eBWd5ig/dicGn5NN4WVpswdIZBD0EtRpRFApvVAYzAQL0Q==
   dependencies:
-    "@gemeente-denhaag/baselayoutprops" "^0.2.3-alpha.7"
+    "@gemeente-denhaag/baselayoutprops" "^0.2.3-alpha.21"
     "@material-ui/core" "^4.11.0"
 
-"@gemeente-denhaag/datadisplay@^0.2.3-alpha.7":
-  version "0.2.3-alpha.7"
-  resolved "https://registry.yarnpkg.com/@gemeente-denhaag/datadisplay/-/datadisplay-0.2.3-alpha.7.tgz#11d2d7283ae61fbe1fcb0f6dacae5a2e6bc0b758"
-  integrity sha512-4WOhpe4tvwmq5SegcnXDG0SeXpu78P8bk07t5aYWxq06XaBJMNMNFbthPcHWu/QeQQnwZU6e96qRQcTXCvvAig==
+"@gemeente-denhaag/datadisplay@^0.2.3-alpha.21":
+  version "0.2.3-alpha.21"
+  resolved "https://registry.yarnpkg.com/@gemeente-denhaag/datadisplay/-/datadisplay-0.2.3-alpha.21.tgz#4d6912ead81f6651d828ef48229cb4bf3a7af921"
+  integrity sha512-cubAF45OvJQpByVIj/WyZvw7DiSvvzft+MdF10HlYQ2Dtf8wgzaoAfAloCZtt0xQ0ZOUIGHuJwPBLhAdYvLLjQ==
   dependencies:
-    "@gemeente-denhaag/avatar" "^0.2.3-alpha.7"
-    "@gemeente-denhaag/badge-counter" "^0.1.1-alpha.7"
-    "@gemeente-denhaag/baseprops" "^0.2.3-alpha.7"
-    "@gemeente-denhaag/divider" "^0.2.3-alpha.7"
-    "@gemeente-denhaag/list" "^0.2.3-alpha.7"
-    "@gemeente-denhaag/typography" "^0.2.3-alpha.7"
+    "@gemeente-denhaag/avatar" "^0.2.3-alpha.21"
+    "@gemeente-denhaag/badge-counter" "^0.1.1-alpha.21"
+    "@gemeente-denhaag/baseprops" "^0.2.3-alpha.21"
+    "@gemeente-denhaag/divider" "^0.2.3-alpha.21"
+    "@gemeente-denhaag/list" "^0.2.3-alpha.21"
+    "@gemeente-denhaag/typography" "^0.2.3-alpha.21"
 
-"@gemeente-denhaag/denhaag-component-library@0.2.3-alpha.7":
-  version "0.2.3-alpha.7"
-  resolved "https://registry.yarnpkg.com/@gemeente-denhaag/denhaag-component-library/-/denhaag-component-library-0.2.3-alpha.7.tgz#e303fa064b04e478f5bfb796902c75cbe04d0202"
-  integrity sha512-hc3aI8wLxNzNUbaQO/tf7nlmPw/+xJSO8t3FE4kk1wnlcUuAiQ+QS69fvuYT/g5gwrI0BJldzH9PF+yYY2BbXA==
+"@gemeente-denhaag/denhaag-component-library@0.2.3-alpha.21":
+  version "0.2.3-alpha.21"
+  resolved "https://registry.yarnpkg.com/@gemeente-denhaag/denhaag-component-library/-/denhaag-component-library-0.2.3-alpha.21.tgz#dd9b60a1fbd899c9ce72edb2728cbdc43e430e67"
+  integrity sha512-6BHnasCrNj0/ZKNR8EWMuIbnflPJ6zN+NuYR9Of8mH3Yb4zRcvcBpAnHbhP83f2KxPHS81WJdYmlXGVMOouTCg==
   dependencies:
-    "@gemeente-denhaag/baseprops" "^0.2.3-alpha.7"
-    "@gemeente-denhaag/datadisplay" "^0.2.3-alpha.7"
-    "@gemeente-denhaag/input" "^0.2.3-alpha.7"
-    "@gemeente-denhaag/layout" "^0.2.3-alpha.7"
-    "@gemeente-denhaag/navigation" "^0.2.3-alpha.7"
-    "@gemeente-denhaag/pickers" "^0.2.3-alpha.7"
-    "@gemeente-denhaag/stylesprovider" "^0.1.1-alpha.7"
-    "@gemeente-denhaag/surfaces" "^0.2.3-alpha.7"
+    "@gemeente-denhaag/baseprops" "^0.2.3-alpha.21"
+    "@gemeente-denhaag/datadisplay" "^0.2.3-alpha.21"
+    "@gemeente-denhaag/input" "^0.2.3-alpha.21"
+    "@gemeente-denhaag/layout" "^0.2.3-alpha.21"
+    "@gemeente-denhaag/navigation" "^0.2.3-alpha.21"
+    "@gemeente-denhaag/pickers" "^0.2.3-alpha.21"
+    "@gemeente-denhaag/stylesprovider" "^0.1.1-alpha.21"
+    "@gemeente-denhaag/surfaces" "^0.2.3-alpha.21"
 
 "@gemeente-denhaag/design-tokens-components@0.2.3-alpha.18":
   version "0.2.3-alpha.18"
   resolved "https://registry.yarnpkg.com/@gemeente-denhaag/design-tokens-components/-/design-tokens-components-0.2.3-alpha.18.tgz#9daac0f443380707aeeb2bb03dee0e4137a3a3b6"
   integrity sha512-DaCKOcrzc7TSb3ETqgaJkOySyVj1GGEwevNw0tZdESVeM7jiJCm1qaPFXOcFdh7UgOhO1vJ8HbWVYEeaFlYSgA==
 
-"@gemeente-denhaag/divider@^0.2.3-alpha.7":
-  version "0.2.3-alpha.7"
-  resolved "https://registry.yarnpkg.com/@gemeente-denhaag/divider/-/divider-0.2.3-alpha.7.tgz#9dc0403f1e0acc9a5bd391ef92f6844c0e461287"
-  integrity sha512-huTeQ7HLw5uDZLX/5ibwS+S/AaXH6hZaEFiWNOT5I7+3eb8hCX307R0HL6ThyLKeAyYGZ64nvb0YuywQX30Uqw==
+"@gemeente-denhaag/divider@^0.2.3-alpha.21":
+  version "0.2.3-alpha.21"
+  resolved "https://registry.yarnpkg.com/@gemeente-denhaag/divider/-/divider-0.2.3-alpha.21.tgz#bcabccd0de20493130553cd2c1da1501c7d649c8"
+  integrity sha512-2Ny1nWUXSCQC8ar9GzrG9nJoNNbnJ/OLp7PdtLFw736ijWfnbOHMECgwlCtAL7W9Ja+7Q+h+lcrt71AkZFkdDg==
   dependencies:
-    "@gemeente-denhaag/basedatadisplayprops" "^0.2.3-alpha.7"
+    "@gemeente-denhaag/basedatadisplayprops" "^0.2.3-alpha.21"
     "@material-ui/core" "^4.11.0"
 
-"@gemeente-denhaag/dotindicator@^0.1.1-alpha.7":
-  version "0.1.1-alpha.7"
-  resolved "https://registry.yarnpkg.com/@gemeente-denhaag/dotindicator/-/dotindicator-0.1.1-alpha.7.tgz#edffb353ca772155fe09064ce60b85c2f506e381"
-  integrity sha512-dzqWKfLehaETKBZZzr740zrv4bF5Njl+J58E0OS9HUbdc2jV9jeIDoh55buNaegHwZyVZVw20Hg+WYvMwfjLcA==
+"@gemeente-denhaag/dotindicator@^0.1.1-alpha.21":
+  version "0.1.1-alpha.21"
+  resolved "https://registry.yarnpkg.com/@gemeente-denhaag/dotindicator/-/dotindicator-0.1.1-alpha.21.tgz#0d5d5e5ae5a88681e5853dbb2a783217edd562b8"
+  integrity sha512-5RnAL3LD8Ww5D0ZqBlcIkYtHJ9TTMh0UGgdE1Gkni/DoW5GC5eh+0adugU6GqCH7pIeDsMUqioi75dknyaUANw==
   dependencies:
-    "@gemeente-denhaag/baseprops" "^0.2.3-alpha.7"
-    clsx "^1.1.1"
+    "@gemeente-denhaag/baseprops" "^0.2.3-alpha.21"
 
-"@gemeente-denhaag/drawer@^0.2.3-alpha.7":
-  version "0.2.3-alpha.7"
-  resolved "https://registry.yarnpkg.com/@gemeente-denhaag/drawer/-/drawer-0.2.3-alpha.7.tgz#d4cca2ccab0ba3723f2aedab1c3f507c5a0f8a23"
-  integrity sha512-qr1sYXxVI6RcHL/07MU6Wn/PXIwpwbw+ZdnpXFFU6TKU3/fAmoO6Yf1V0wRWirtzTowTWMMkQ64HwbutJXUFxg==
+"@gemeente-denhaag/drawer@^0.2.3-alpha.21":
+  version "0.2.3-alpha.21"
+  resolved "https://registry.yarnpkg.com/@gemeente-denhaag/drawer/-/drawer-0.2.3-alpha.21.tgz#872aac93357ee3ee818727a87eccb294d21a2375"
+  integrity sha512-6ImYHAU7NPdr5hVt+O4Hf8or3XByC5brceAtrB2huB9/E7E28ymkp2JT5Uxf4cGjRK1UeY/+AtSMSWwy73C8+w==
   dependencies:
-    "@gemeente-denhaag/baseprops" "^0.2.3-alpha.7"
+    "@gemeente-denhaag/baseprops" "^0.2.3-alpha.21"
     "@material-ui/core" "^4.11.0"
 
-"@gemeente-denhaag/formcontrol@^0.2.3-alpha.7":
-  version "0.2.3-alpha.7"
-  resolved "https://registry.yarnpkg.com/@gemeente-denhaag/formcontrol/-/formcontrol-0.2.3-alpha.7.tgz#8c0dcc86d1ea13d2183dbdd6e03dbbd7d3c5973c"
-  integrity sha512-FrgCg2gEYrPDXBkrBiEl1k0yes48EWqU2wGU7rMLLB85MV+lCzQoJxulsuoINMhMf4wFcYGb3mHB/WR7tyaNjw==
+"@gemeente-denhaag/formcontrol@^0.2.3-alpha.21":
+  version "0.2.3-alpha.21"
+  resolved "https://registry.yarnpkg.com/@gemeente-denhaag/formcontrol/-/formcontrol-0.2.3-alpha.21.tgz#05fce1401afa2abedf793816c1716c97635feb58"
+  integrity sha512-56CnN4DleC3Bj7W1xvmWdvbnDIysb8V4p52ZNsvEb2F/E76CMDntWQ+LvdvuLQfmSzSJ5UycYiNvNSo/RF2bbg==
   dependencies:
     "@material-ui/core" "^4.11.0"
 
-"@gemeente-denhaag/formcontrollabel@^0.2.3-alpha.7":
-  version "0.2.3-alpha.7"
-  resolved "https://registry.yarnpkg.com/@gemeente-denhaag/formcontrollabel/-/formcontrollabel-0.2.3-alpha.7.tgz#06310c7f82ad4001a23ccbfc01239fb3ed349198"
-  integrity sha512-wyQqSze1D3g8hCWDq5INM81lnpvg4zOTYp6mEvquw8Zwm5f22Op/Dm8NwVsc6m/rNv1+04iZcHXQLg9t5/Jg1w==
+"@gemeente-denhaag/formcontrollabel@^0.2.3-alpha.21":
+  version "0.2.3-alpha.21"
+  resolved "https://registry.yarnpkg.com/@gemeente-denhaag/formcontrollabel/-/formcontrollabel-0.2.3-alpha.21.tgz#06d544fcae64a72b2ec46c4f355361f3dff5b5b1"
+  integrity sha512-pz47OtY/9144nNbmrP+Hw/OxA9E2CCg/v4bOtxi9AY3NLSwHQ+I4QG/FO4g6awoR8vAJCgbTxNMIGIJEg4erMA==
   dependencies:
-    "@gemeente-denhaag/baseprops" "^0.2.3-alpha.7"
-    "@gemeente-denhaag/typography" "^0.2.3-alpha.7"
+    "@gemeente-denhaag/baseprops" "^0.2.3-alpha.21"
+    "@gemeente-denhaag/typography" "^0.2.3-alpha.21"
     "@material-ui/core" "^4.11.0"
 
-"@gemeente-denhaag/formgroup@^0.2.3-alpha.7":
-  version "0.2.3-alpha.7"
-  resolved "https://registry.yarnpkg.com/@gemeente-denhaag/formgroup/-/formgroup-0.2.3-alpha.7.tgz#9a4233ad4244cef030acfefd753cdbf3cd75ce3f"
-  integrity sha512-f8jdC2elkFSGADI3vL9XmKinhIDZTRsE+oHbdNS7bj8JVPv2NjpnO4bYhoc/7JOjI79a2QGIjBovHgKkRI546w==
+"@gemeente-denhaag/formgroup@^0.2.3-alpha.21":
+  version "0.2.3-alpha.21"
+  resolved "https://registry.yarnpkg.com/@gemeente-denhaag/formgroup/-/formgroup-0.2.3-alpha.21.tgz#e82f10b6d6f9f22c689f7c0c67388a8befcb36e8"
+  integrity sha512-RWIv4mvq3Bs0j6RWpZvuqQbgyX9vpCZRGhBt95D8WMVlxnpOOX7QkTr3ns+Q4zD52I7aOTp+HVRiD6s4hBhE8g==
   dependencies:
-    "@gemeente-denhaag/baseprops" "^0.2.3-alpha.7"
-    "@gemeente-denhaag/typography" "^0.2.3-alpha.7"
+    "@gemeente-denhaag/baseprops" "^0.2.3-alpha.21"
+    "@gemeente-denhaag/typography" "^0.2.3-alpha.21"
     "@material-ui/core" "^4.11.0"
 
-"@gemeente-denhaag/grid@^0.2.3-alpha.7":
-  version "0.2.3-alpha.7"
-  resolved "https://registry.yarnpkg.com/@gemeente-denhaag/grid/-/grid-0.2.3-alpha.7.tgz#86a466f250c68390415ffb3780254d118883a11a"
-  integrity sha512-yZa3nqm1rBtqTAo+LybMfRFyh/Wuma0nCMTur+SHLdRH9W9TpLRUvjOsBh0zZ4lk/K8a8T9Dpdeo+eE89SfnNQ==
+"@gemeente-denhaag/grid@^0.2.3-alpha.21":
+  version "0.2.3-alpha.21"
+  resolved "https://registry.yarnpkg.com/@gemeente-denhaag/grid/-/grid-0.2.3-alpha.21.tgz#5634ff66a95075c2cb7116861de3f75ed22dd855"
+  integrity sha512-PSO3kqOBqU/+7Iq5S8eto7BnPaRKl6iLpFL0PebEkk/RcUk2YZWreV5pJrasrsAggxSEJU3TiPyWvxcLBGM9ig==
   dependencies:
-    "@gemeente-denhaag/baselayoutprops" "^0.2.3-alpha.7"
+    "@gemeente-denhaag/baselayoutprops" "^0.2.3-alpha.21"
     "@material-ui/core" "^4.11.0"
 
-"@gemeente-denhaag/gridlist@^0.2.3-alpha.7":
-  version "0.2.3-alpha.7"
-  resolved "https://registry.yarnpkg.com/@gemeente-denhaag/gridlist/-/gridlist-0.2.3-alpha.7.tgz#8ab3a66296a0302b4b55c79ab4f9e2f05b26fc1e"
-  integrity sha512-jJc5xCGS96oY3YnzlfWDijsxvlf0Jn9D4/LKkcziRCwoFnkdOJpHywPjQurg9kroJcycmvg6gBQzmo359+nLEw==
+"@gemeente-denhaag/gridlist@^0.2.3-alpha.21":
+  version "0.2.3-alpha.21"
+  resolved "https://registry.yarnpkg.com/@gemeente-denhaag/gridlist/-/gridlist-0.2.3-alpha.21.tgz#67f8570df2a2554cb42c453be2dc0a18f568b746"
+  integrity sha512-8dZ6ytcPznIuQuFYNgHTDwCz3F5yIJssNCr2BQw8kL8EyZJUnt8XifTdybRPjC9i+lLTz1PmXFCMEGGhbOM57w==
   dependencies:
-    "@gemeente-denhaag/baselayoutprops" "^0.2.3-alpha.7"
+    "@gemeente-denhaag/baselayoutprops" "^0.2.3-alpha.21"
     "@material-ui/core" "^4.11.0"
 
-"@gemeente-denhaag/hidden@^0.2.3-alpha.7":
-  version "0.2.3-alpha.7"
-  resolved "https://registry.yarnpkg.com/@gemeente-denhaag/hidden/-/hidden-0.2.3-alpha.7.tgz#25098aeca9eb1a7de0d41aec21196622e48968c0"
-  integrity sha512-6X8vspKlEQMx4O2eB6CEyLxbOmYk/pQmNCCzpNBuUXtHwUEyj0c/zLe98arPrKPShSDynFFjetcHWjhwA8S+Dw==
+"@gemeente-denhaag/hidden@^0.2.3-alpha.21":
+  version "0.2.3-alpha.21"
+  resolved "https://registry.yarnpkg.com/@gemeente-denhaag/hidden/-/hidden-0.2.3-alpha.21.tgz#abee2533615810d6bf40614c88a97d14ccdd7b5f"
+  integrity sha512-+g7fDHQrlfRjLS8wus8lcVfXg7SDF8BABuWFKBRgHYPpt4xS4aB2217R99b7WJZALjQhn7oeR2QIuftPDXWYhQ==
   dependencies:
-    "@gemeente-denhaag/baseprops" "^0.2.3-alpha.7"
+    "@gemeente-denhaag/baseprops" "^0.2.3-alpha.21"
     "@material-ui/core" "^4.11.0"
 
-"@gemeente-denhaag/iconbutton@^0.2.3-alpha.7":
-  version "0.2.3-alpha.7"
-  resolved "https://registry.yarnpkg.com/@gemeente-denhaag/iconbutton/-/iconbutton-0.2.3-alpha.7.tgz#f38dae81f85b6d34d2335367d6cfdc438ee6cef8"
-  integrity sha512-ijo10awiFF+thHBmNK6J6asZHQzl9VFieCalkoSkd/bHJQB98d9qTG37qJcK+e3eGyuBKaSk0HLODhY9g1JKiQ==
+"@gemeente-denhaag/iconbutton@^0.2.3-alpha.21":
+  version "0.2.3-alpha.21"
+  resolved "https://registry.yarnpkg.com/@gemeente-denhaag/iconbutton/-/iconbutton-0.2.3-alpha.21.tgz#db1721b399b19d1aee06b74ab9d389bbe191a2d4"
+  integrity sha512-ZzLhTYCFDXjQLHiPSxy4U4ocJUH/cZ9/7ag9via8WhmSp8sLO6iGViDR388rfzYuardSjR7aqz4QkGKX33E6ew==
   dependencies:
-    "@gemeente-denhaag/baseprops" "^0.2.3-alpha.7"
+    "@gemeente-denhaag/baseprops" "^0.2.3-alpha.21"
     "@material-ui/core" "^4.11.0"
 
 "@gemeente-denhaag/icons@^0.2.3-alpha.16":
@@ -1607,82 +1606,82 @@
     "@gemeente-denhaag/baseprops" "^0.2.3-alpha.18"
     "@material-ui/core" "^4.11.0"
 
-"@gemeente-denhaag/icons@^0.2.3-alpha.7":
-  version "0.2.3-alpha.7"
-  resolved "https://registry.yarnpkg.com/@gemeente-denhaag/icons/-/icons-0.2.3-alpha.7.tgz#e06cc17fdcc0dd78c20a4eefb7707f1becb40e6c"
-  integrity sha512-LI7DZX4mmEYvOO6dyBnVK4iwcy0+fbWUtnl41r/h/TMeO0odYVND0aiTpKroyGaLY+gNH7wt1s8EHg8d0ClZpg==
+"@gemeente-denhaag/icons@^0.2.3-alpha.21":
+  version "0.2.3-alpha.21"
+  resolved "https://registry.yarnpkg.com/@gemeente-denhaag/icons/-/icons-0.2.3-alpha.21.tgz#de70281b68fc24a16ff3f0d45ce0320e2e5cbbfb"
+  integrity sha512-xbHC6Nk5eEi6VOBj9l2jDM7/IxKmpO48kI7nREpGhiERdRZBkYxC766IW+tD2SQjewD2OGLINEZuf542JrEmEA==
   dependencies:
-    "@gemeente-denhaag/baseprops" "^0.2.3-alpha.7"
+    "@gemeente-denhaag/baseprops" "^0.2.3-alpha.21"
     "@material-ui/core" "^4.11.0"
 
-"@gemeente-denhaag/input@^0.2.3-alpha.7":
-  version "0.2.3-alpha.7"
-  resolved "https://registry.yarnpkg.com/@gemeente-denhaag/input/-/input-0.2.3-alpha.7.tgz#cfbd2ebcc7468583b3e8cdd2230c2d358dd2e6b6"
-  integrity sha512-7cToZbZupLbOTSc04j8/eyFxPDzVmKT8tCA9RuWQuEt13Wvpz+F6TAdV3KqbyaeJyC+cdmtZL81ZQ8MQnRGpEQ==
+"@gemeente-denhaag/input@^0.2.3-alpha.21":
+  version "0.2.3-alpha.21"
+  resolved "https://registry.yarnpkg.com/@gemeente-denhaag/input/-/input-0.2.3-alpha.21.tgz#0220a64b17329bfc90839cca9fff2720f1e61c1f"
+  integrity sha512-rTTkV9Xi5gnvZ3htd6nSSdANK+5nVHPkNtzqPNZNPMiuB8cb2YWur9TEgm5Hsdz3KjMvUkSIPkBm8V4Fm4dvVw==
   dependencies:
-    "@gemeente-denhaag/baseprops" "^0.2.3-alpha.7"
-    "@gemeente-denhaag/button" "^0.2.3-alpha.7"
-    "@gemeente-denhaag/checkbox" "^0.2.3-alpha.7"
-    "@gemeente-denhaag/formcontrol" "^0.2.3-alpha.7"
-    "@gemeente-denhaag/formcontrollabel" "^0.2.3-alpha.7"
-    "@gemeente-denhaag/formgroup" "^0.2.3-alpha.7"
-    "@gemeente-denhaag/iconbutton" "^0.2.3-alpha.7"
-    "@gemeente-denhaag/inputlabel" "^0.2.3-alpha.7"
-    "@gemeente-denhaag/pickers" "^0.2.3-alpha.7"
-    "@gemeente-denhaag/radio" "^0.2.3-alpha.7"
-    "@gemeente-denhaag/select" "^0.2.3-alpha.7"
-    "@gemeente-denhaag/switch" "^0.2.3-alpha.7"
-    "@gemeente-denhaag/textfield" "^0.2.3-alpha.7"
+    "@gemeente-denhaag/baseprops" "^0.2.3-alpha.21"
+    "@gemeente-denhaag/button" "^0.2.3-alpha.21"
+    "@gemeente-denhaag/checkbox" "^0.2.3-alpha.21"
+    "@gemeente-denhaag/formcontrol" "^0.2.3-alpha.21"
+    "@gemeente-denhaag/formcontrollabel" "^0.2.3-alpha.21"
+    "@gemeente-denhaag/formgroup" "^0.2.3-alpha.21"
+    "@gemeente-denhaag/iconbutton" "^0.2.3-alpha.21"
+    "@gemeente-denhaag/inputlabel" "^0.2.3-alpha.21"
+    "@gemeente-denhaag/pickers" "^0.2.3-alpha.21"
+    "@gemeente-denhaag/radio" "^0.2.3-alpha.21"
+    "@gemeente-denhaag/select" "^0.2.3-alpha.21"
+    "@gemeente-denhaag/switch" "^0.2.3-alpha.21"
+    "@gemeente-denhaag/textfield" "^0.2.3-alpha.21"
 
-"@gemeente-denhaag/inputlabel@^0.2.3-alpha.7":
-  version "0.2.3-alpha.7"
-  resolved "https://registry.yarnpkg.com/@gemeente-denhaag/inputlabel/-/inputlabel-0.2.3-alpha.7.tgz#e4e01e5f1521d6675d59f3c99839ccc7ac393898"
-  integrity sha512-Sg5oI8pqATPwV4PdfipH/uKnxeUwNEMkuYbrjKRFpS7GrtiD8OHubG3xlnkVmdBlEGMoZaOKL1ziqQJOdS6JNg==
+"@gemeente-denhaag/inputlabel@^0.2.3-alpha.21":
+  version "0.2.3-alpha.21"
+  resolved "https://registry.yarnpkg.com/@gemeente-denhaag/inputlabel/-/inputlabel-0.2.3-alpha.21.tgz#a92573eddae30da5de04995979d6a95b2020234d"
+  integrity sha512-nf8UAVAeIuGU/Fc8qn3MR/yPPCN5LO+RSYhBM7R6gzlyLDn5DEcS50mHTkPLqIFJYHJWnmokf2rhgvNs5j3Rsw==
   dependencies:
-    "@gemeente-denhaag/baseprops" "^0.2.3-alpha.7"
+    "@gemeente-denhaag/baseprops" "^0.2.3-alpha.21"
     "@material-ui/core" "^4.11.0"
 
-"@gemeente-denhaag/layout@^0.2.3-alpha.7":
-  version "0.2.3-alpha.7"
-  resolved "https://registry.yarnpkg.com/@gemeente-denhaag/layout/-/layout-0.2.3-alpha.7.tgz#3c0f87a40b1bbe7b8b0ae095daaa52ab29fc1596"
-  integrity sha512-GJrFp2ww8KoVWuEbTBC3JJdp1FfD768N+pyynfvSqb6pUfdEcR54NG5tWL5duTnbOjC4qBL3jVamZJgrS6uLTQ==
+"@gemeente-denhaag/layout@^0.2.3-alpha.21":
+  version "0.2.3-alpha.21"
+  resolved "https://registry.yarnpkg.com/@gemeente-denhaag/layout/-/layout-0.2.3-alpha.21.tgz#50e999a4e1286637e63ed09f80f9cfb85889bcd9"
+  integrity sha512-wB7driV0wOuknbNiYDZ7B56dPXB6R/1LiKBTjmzgDd1igMMaOUAhbpnYELzvDulckFdkYLJKePLXT1Tx3NHQ5w==
   dependencies:
-    "@gemeente-denhaag/baselayoutprops" "^0.2.3-alpha.7"
-    "@gemeente-denhaag/box" "^0.2.3-alpha.7"
-    "@gemeente-denhaag/container" "^0.2.3-alpha.7"
-    "@gemeente-denhaag/grid" "^0.2.3-alpha.7"
-    "@gemeente-denhaag/gridlist" "^0.2.3-alpha.7"
-    "@gemeente-denhaag/hidden" "^0.2.3-alpha.7"
+    "@gemeente-denhaag/baselayoutprops" "^0.2.3-alpha.21"
+    "@gemeente-denhaag/box" "^0.2.3-alpha.21"
+    "@gemeente-denhaag/container" "^0.2.3-alpha.21"
+    "@gemeente-denhaag/grid" "^0.2.3-alpha.21"
+    "@gemeente-denhaag/gridlist" "^0.2.3-alpha.21"
+    "@gemeente-denhaag/hidden" "^0.2.3-alpha.21"
 
-"@gemeente-denhaag/list@^0.2.3-alpha.7":
-  version "0.2.3-alpha.7"
-  resolved "https://registry.yarnpkg.com/@gemeente-denhaag/list/-/list-0.2.3-alpha.7.tgz#7b4e3be32774bfdd57ee548dcee3a7a8040e0db8"
-  integrity sha512-BgREnAp1ibU55j5NMimGRb/+VO6AmWFpvtFl9C20sGf6o+4LkYEF7XKm7q5PTX+duzVXwbal8Tp8fmSNUp+5Eg==
+"@gemeente-denhaag/list@^0.2.3-alpha.21":
+  version "0.2.3-alpha.21"
+  resolved "https://registry.yarnpkg.com/@gemeente-denhaag/list/-/list-0.2.3-alpha.21.tgz#238c8980e3db04955a07b42eb0f3d9eafaa93523"
+  integrity sha512-R1CjAhOmgxYlcJL03k3Ci8oHJgbxyWH1HreW8KkgefZUTHX9xB6MP8THhNyaM5+lJf4Tw3pRYmkIn5y72ya6jA==
   dependencies:
-    "@gemeente-denhaag/baseprops" "^0.2.3-alpha.7"
-    "@gemeente-denhaag/iconbutton" "^0.2.3-alpha.7"
-    "@gemeente-denhaag/icons" "^0.2.3-alpha.7"
+    "@gemeente-denhaag/baseprops" "^0.2.3-alpha.21"
+    "@gemeente-denhaag/iconbutton" "^0.2.3-alpha.21"
+    "@gemeente-denhaag/icons" "^0.2.3-alpha.21"
     "@material-ui/core" "^4.11.0"
 
-"@gemeente-denhaag/menu@^0.2.3-alpha.7":
-  version "0.2.3-alpha.7"
-  resolved "https://registry.yarnpkg.com/@gemeente-denhaag/menu/-/menu-0.2.3-alpha.7.tgz#427968ff4ef620743a93235409c690fb93d9c816"
-  integrity sha512-v0MQ0NaLCyU9/4fiTFcNXNI2qbMwKXI17s4Eolpj/UKsprHAYZyetNfXm4AGjxUw0bq2FqHhwmEiSzxHK+SqUw==
+"@gemeente-denhaag/menu@^0.2.3-alpha.21":
+  version "0.2.3-alpha.21"
+  resolved "https://registry.yarnpkg.com/@gemeente-denhaag/menu/-/menu-0.2.3-alpha.21.tgz#c3586c0e719e2f0a4bd7106e7fa59c411b891b53"
+  integrity sha512-SFHp6Uuu+ThsVJnyA8/fkzGTdDQ4szurLKWMkkN2O9mHkhcsxpnjTrZtMgcrqY2tSbi/7XgAbFRU3Bc7Dnb4lw==
   dependencies:
-    "@gemeente-denhaag/baseprops" "^0.2.3-alpha.7"
-    "@gemeente-denhaag/icons" "^0.2.3-alpha.7"
+    "@gemeente-denhaag/baseprops" "^0.2.3-alpha.21"
+    "@gemeente-denhaag/icons" "^0.2.3-alpha.21"
 
-"@gemeente-denhaag/navigation@^0.2.3-alpha.7":
-  version "0.2.3-alpha.7"
-  resolved "https://registry.yarnpkg.com/@gemeente-denhaag/navigation/-/navigation-0.2.3-alpha.7.tgz#e985afdcab3332c81b143463d16cf166db469ba0"
-  integrity sha512-cfU3QswO4OU96iMyxX/FKkhfbmTQqcwrqIItMPZJWw0E/QeAeyjgOByjHUX9oIVgcgoEzWu54h6UODxEY6k7cw==
+"@gemeente-denhaag/navigation@^0.2.3-alpha.21":
+  version "0.2.3-alpha.21"
+  resolved "https://registry.yarnpkg.com/@gemeente-denhaag/navigation/-/navigation-0.2.3-alpha.21.tgz#4f2db2889034de9bf0bdd92d96336fa59adb7d3c"
+  integrity sha512-ww6KWuTLazzriQ2ce9g9zEmjJ0E/y0C8znGMuew0b0XAPRWiMMyV0L/2YK2BlTn4YAXDaE/h/uSwYcCiyd3rkQ==
   dependencies:
-    "@gemeente-denhaag/baseprops" "^0.2.3-alpha.7"
-    "@gemeente-denhaag/drawer" "^0.2.3-alpha.7"
-    "@gemeente-denhaag/menu" "^0.2.3-alpha.7"
-    "@gemeente-denhaag/swipeabledrawer" "^0.2.3-alpha.7"
-    "@gemeente-denhaag/tab" "^0.2.3-alpha.7"
-    "@gemeente-denhaag/timeline" "^0.2.3-alpha.7"
+    "@gemeente-denhaag/baseprops" "^0.2.3-alpha.21"
+    "@gemeente-denhaag/drawer" "^0.2.3-alpha.21"
+    "@gemeente-denhaag/menu" "^0.2.3-alpha.21"
+    "@gemeente-denhaag/swipeabledrawer" "^0.2.3-alpha.21"
+    "@gemeente-denhaag/tab" "^0.2.3-alpha.21"
+    "@gemeente-denhaag/timeline" "^0.2.3-alpha.21"
     "@material-ui/core" "^4.11.0"
     "@material-ui/lab" "^4.0.0-alpha"
 
@@ -1694,113 +1693,112 @@
     "@gemeente-denhaag/baseprops" "^0.1.7"
     "@material-ui/core" "^4.11.0"
 
-"@gemeente-denhaag/pickers@^0.2.3-alpha.7":
-  version "0.2.3-alpha.7"
-  resolved "https://registry.yarnpkg.com/@gemeente-denhaag/pickers/-/pickers-0.2.3-alpha.7.tgz#1ac0c3be42b6b0596154948d172007856fea0cc8"
-  integrity sha512-hBRPMnrSCn83SPfxCvo/1IzgUlCNRCrfpuxB0y0zkc36do6hXxPa/6vs9Qra2MNST5MUXVgLGPiJ1AJucMKHDQ==
+"@gemeente-denhaag/pickers@^0.2.3-alpha.21":
+  version "0.2.3-alpha.21"
+  resolved "https://registry.yarnpkg.com/@gemeente-denhaag/pickers/-/pickers-0.2.3-alpha.21.tgz#aa632f238b548c5748e626986c5c928292b86ee0"
+  integrity sha512-bGHQHxl+FXaUB9NXRqx+Y9unT53CCyA7TGFpI66jPUZw/kg2Te0K4qW7swxa4RQfdcMs1J19sCEZXuFpYOjs1A==
   dependencies:
-    "@gemeente-denhaag/pickersutilsprovider" "^0.2.3-alpha.7"
+    "@gemeente-denhaag/pickersutilsprovider" "^0.2.3-alpha.21"
     "@material-ui/core" "^4.11.0"
     "@material-ui/pickers" "^3.2.10"
 
-"@gemeente-denhaag/pickersutilsprovider@^0.2.3-alpha.7":
-  version "0.2.3-alpha.7"
-  resolved "https://registry.yarnpkg.com/@gemeente-denhaag/pickersutilsprovider/-/pickersutilsprovider-0.2.3-alpha.7.tgz#bd59dbff60af1719707da44b9551e7a471eea249"
-  integrity sha512-ut8sPyVBA6v7ccIzh9LevjPj/QLA9lqQ6HIAjqyxkHHJMUoEg0UOLxFA2+XjPEtAe+J6GltficwXeerdAuW/wA==
+"@gemeente-denhaag/pickersutilsprovider@^0.2.3-alpha.21":
+  version "0.2.3-alpha.21"
+  resolved "https://registry.yarnpkg.com/@gemeente-denhaag/pickersutilsprovider/-/pickersutilsprovider-0.2.3-alpha.21.tgz#377f4065a36e18f7cd7ddb46035ea70482659ba5"
+  integrity sha512-g7Cmzxvi9TaU7Knl6A1P7l7y+YLJ/v1QbXnjCIJsTlNM9FW7BzIONGfvJ+4kMD3GT5r1sKWNIeDOiIoD3z7JUQ==
   dependencies:
     "@material-ui/pickers" "^3.2.10"
 
-"@gemeente-denhaag/radio@^0.2.3-alpha.7":
-  version "0.2.3-alpha.7"
-  resolved "https://registry.yarnpkg.com/@gemeente-denhaag/radio/-/radio-0.2.3-alpha.7.tgz#cf3ad0addc91d252ffcdbf32dd1920b9bef1084e"
-  integrity sha512-OG3jD6fDRax96AN2hM2ZKBB3Yq0rLA0Y9J1QORm/TfzGA/PdYzsnoseQUCPSt0jrLA3kLZ5nZXZ9yoV78dgw3A==
+"@gemeente-denhaag/radio@^0.2.3-alpha.21":
+  version "0.2.3-alpha.21"
+  resolved "https://registry.yarnpkg.com/@gemeente-denhaag/radio/-/radio-0.2.3-alpha.21.tgz#7411db561e221720e94c08f798fa1e482d6ac6cb"
+  integrity sha512-gc5hPdQBQ7FUZKt+rg1R01Y/maMBOB81aGe3JLU242ZnXZW7bwHNdXd8Yg6snlcqNFAJYVVbRSsr2whcdvaTvw==
   dependencies:
     "@material-ui/core" "^4.11.2"
 
-"@gemeente-denhaag/select@^0.2.3-alpha.7":
-  version "0.2.3-alpha.7"
-  resolved "https://registry.yarnpkg.com/@gemeente-denhaag/select/-/select-0.2.3-alpha.7.tgz#c18388aa4b2d2cca200361e7630c98e33e8ee531"
-  integrity sha512-NKuo6irjdUHu76d2NBAgN47PWjdGqAQoScg81C+w/WuJA3t+apudKe9CS8rXGi59Jg35BJLxm9rE+SjBY19KrQ==
+"@gemeente-denhaag/select@^0.2.3-alpha.21":
+  version "0.2.3-alpha.21"
+  resolved "https://registry.yarnpkg.com/@gemeente-denhaag/select/-/select-0.2.3-alpha.21.tgz#edbd6b67f4fb1eea1767754c02d28ea282ba6ea2"
+  integrity sha512-oukwihHc/WbuyCrgtziGRf31bCOXP7v5WAC/BmeSOlfbLDnJcR01M0Bue4Gjrvl94idSNrTWBglQEHUJvIimpw==
   dependencies:
-    "@gemeente-denhaag/baseprops" "^0.2.3-alpha.7"
+    "@gemeente-denhaag/baseprops" "^0.2.3-alpha.21"
     "@material-ui/core" "^4.11.0"
 
-"@gemeente-denhaag/stylesprovider@^0.1.1-alpha.7":
-  version "0.1.1-alpha.7"
-  resolved "https://registry.yarnpkg.com/@gemeente-denhaag/stylesprovider/-/stylesprovider-0.1.1-alpha.7.tgz#e15209ad9bd6e11192278c0730da395460ca6aa5"
-  integrity sha512-KO8har4Dg6IUTWYljYN0ZvzrZlX/fXRb0CUMHzmJtxMvH2ts4o1x5Q3QmOaZqBIJKPU9jcks7LyQzA9l3lKqUA==
+"@gemeente-denhaag/stylesprovider@^0.1.1-alpha.21":
+  version "0.1.1-alpha.21"
+  resolved "https://registry.yarnpkg.com/@gemeente-denhaag/stylesprovider/-/stylesprovider-0.1.1-alpha.21.tgz#1450660075f8b77dc18c17d040273e4ca09b1091"
+  integrity sha512-IO/qOAXiDoKtJ/aRbR/Nyvx4L4dNMjPkyqbwm+o4130iK6guZKwBRTO/3S68TZt9RTtWdqZ5DQeRlVV9NSRdHQ==
   dependencies:
     "@material-ui/core" "^4.11.0"
 
-"@gemeente-denhaag/surfaces@^0.2.3-alpha.7":
-  version "0.2.3-alpha.7"
-  resolved "https://registry.yarnpkg.com/@gemeente-denhaag/surfaces/-/surfaces-0.2.3-alpha.7.tgz#2cd36f7b3fd18b81463917b35e80230ff2148ef5"
-  integrity sha512-nw6Fp1t+NotnKRnyqiYpwbW4HGZDaYP9CXesLKNf7nTrVsX3X/1tcN+3cwrjKf4mokK2mJbDXHQAyvQNS86Udw==
+"@gemeente-denhaag/surfaces@^0.2.3-alpha.21":
+  version "0.2.3-alpha.21"
+  resolved "https://registry.yarnpkg.com/@gemeente-denhaag/surfaces/-/surfaces-0.2.3-alpha.21.tgz#49634c9c74de5685ad8712483646d83b764f10d0"
+  integrity sha512-3MRqHUKLvHTbj23Dmh6rl4q/bzCFsUM93zt5FpSqk3wuMw0ypHC5wClcIv2QfdByS825UoUnTeIpEBmdjG7/Hg==
   dependencies:
-    "@gemeente-denhaag/accordion" "^0.2.3-alpha.7"
-    "@gemeente-denhaag/appbar" "^0.2.3-alpha.7"
-    "@gemeente-denhaag/baseprops" "^0.2.3-alpha.7"
-    "@gemeente-denhaag/card" "^0.2.3-alpha.7"
+    "@gemeente-denhaag/accordion" "^0.2.3-alpha.21"
+    "@gemeente-denhaag/appbar" "^0.2.3-alpha.21"
+    "@gemeente-denhaag/baseprops" "^0.2.3-alpha.21"
+    "@gemeente-denhaag/card" "^0.2.3-alpha.21"
     "@gemeente-denhaag/paper" "^0.1.7"
-    "@gemeente-denhaag/toolbar" "^0.2.3-alpha.7"
+    "@gemeente-denhaag/toolbar" "^0.2.3-alpha.21"
 
-"@gemeente-denhaag/swipeabledrawer@^0.2.3-alpha.7":
-  version "0.2.3-alpha.7"
-  resolved "https://registry.yarnpkg.com/@gemeente-denhaag/swipeabledrawer/-/swipeabledrawer-0.2.3-alpha.7.tgz#51afcc4d666b039b56514350b9026ffadeb6eb72"
-  integrity sha512-RsxZF2+p4H5+GOB68FRXFLLP43hbHZDkJIyEQfmStewCSkvj19qB4cNGjahlDv3YYZPdbwjC/99hj28MEFXXnQ==
+"@gemeente-denhaag/swipeabledrawer@^0.2.3-alpha.21":
+  version "0.2.3-alpha.21"
+  resolved "https://registry.yarnpkg.com/@gemeente-denhaag/swipeabledrawer/-/swipeabledrawer-0.2.3-alpha.21.tgz#d043dd9d21946daa820c305ed35372f00431df82"
+  integrity sha512-8ol17Z6TpTCUMMZi5pUZiO9q8pqhjHFxFy/1tn2LBw79x66TDvzp0dyc8VuVwC7yb19HFTaHxQ4T9lvbW/BdKQ==
   dependencies:
-    "@gemeente-denhaag/baseprops" "^0.2.3-alpha.7"
+    "@gemeente-denhaag/baseprops" "^0.2.3-alpha.21"
     "@material-ui/core" "^4.11.0"
 
-"@gemeente-denhaag/switch@^0.2.3-alpha.7":
-  version "0.2.3-alpha.7"
-  resolved "https://registry.yarnpkg.com/@gemeente-denhaag/switch/-/switch-0.2.3-alpha.7.tgz#ebb28e0b9f786ae941a88f89fe68eaae99ff7285"
-  integrity sha512-i+G3Ig/iVBPbQo8nR9LnwgjRLhszGfZ0eX52dbYqe2NmeHmv6gzzvaztnGB38cDvk82uyDy7VgosP2goKL817g==
+"@gemeente-denhaag/switch@^0.2.3-alpha.21":
+  version "0.2.3-alpha.21"
+  resolved "https://registry.yarnpkg.com/@gemeente-denhaag/switch/-/switch-0.2.3-alpha.21.tgz#062ccb26cbcd472fa8e77f9c867edf4c79360c4d"
+  integrity sha512-6NztRb49eyEP13+bnTqPmhV43J+solYNExIfG6IM/Q1yqMTVjxPvgaSVsGrcj9Z/vyk414nTkDL864yF4PX+ng==
   dependencies:
-    "@gemeente-denhaag/baseprops" "^0.2.3-alpha.7"
+    "@gemeente-denhaag/baseprops" "^0.2.3-alpha.21"
     "@material-ui/core" "^4.11.0"
 
-"@gemeente-denhaag/tab@^0.2.3-alpha.7":
-  version "0.2.3-alpha.7"
-  resolved "https://registry.yarnpkg.com/@gemeente-denhaag/tab/-/tab-0.2.3-alpha.7.tgz#63a3db3bbcf162a7dc8535e1bb882bb64531066e"
-  integrity sha512-GyHEMmqB8PKfPrPX0jVIKXqW6013ETOVZ91OCORjFNHXC5PrZ8YoeQIwHdOHcdBOLwKt2QaRnobSedYKq4SAJw==
+"@gemeente-denhaag/tab@^0.2.3-alpha.21":
+  version "0.2.3-alpha.21"
+  resolved "https://registry.yarnpkg.com/@gemeente-denhaag/tab/-/tab-0.2.3-alpha.21.tgz#df1b34bf1cdddc2c3f29cd2ebae59feec4d0c2b0"
+  integrity sha512-rlqgpVvOJeGTO6G8XJm7ecHN9Jog9MfneMxx9Oa9Roh22EgKfwjuYM+b9GOo5VPjVusAXGipnEeklvZdmJ2z8A==
   dependencies:
-    "@gemeente-denhaag/baseprops" "^0.2.3-alpha.7"
+    "@gemeente-denhaag/baseprops" "^0.2.3-alpha.21"
     "@material-ui/core" "^4.11.0"
 
-"@gemeente-denhaag/textfield@^0.2.3-alpha.7":
-  version "0.2.3-alpha.7"
-  resolved "https://registry.yarnpkg.com/@gemeente-denhaag/textfield/-/textfield-0.2.3-alpha.7.tgz#c74f08966b60a8976c9c3107ae15e52addc079c5"
-  integrity sha512-EYrzcVo48FixtkigMkIH4PZz1xBQz38fIep98V07LA9al2r+B+9EOBeccpbnQISnmpSdFbD6hTQF6OcdFMJQyA==
+"@gemeente-denhaag/textfield@^0.2.3-alpha.21":
+  version "0.2.3-alpha.21"
+  resolved "https://registry.yarnpkg.com/@gemeente-denhaag/textfield/-/textfield-0.2.3-alpha.21.tgz#54d8f7af876afff642d69ff9f71f41b0a968e824"
+  integrity sha512-4I24l8Rli+DxLyEs8A8kFERnjDkFqQZilxukFOidIPsLduKhPDFuEBSUXSUgymd1nNhE0MJslCO0EpekoF0f9w==
   dependencies:
-    "@gemeente-denhaag/baseprops" "^0.2.3-alpha.7"
+    "@gemeente-denhaag/baseprops" "^0.2.3-alpha.21"
     "@material-ui/core" "^4.11.0"
 
-"@gemeente-denhaag/timeline@^0.2.3-alpha.7":
-  version "0.2.3-alpha.7"
-  resolved "https://registry.yarnpkg.com/@gemeente-denhaag/timeline/-/timeline-0.2.3-alpha.7.tgz#3b033e4cb9588dba8ff2b8f75a43dfbc895344e3"
-  integrity sha512-K+UyKMLYyb6p2ASydFOsMU6PxR930WWbsb2XqWKi9u/XLAUths4yc0zNP+QI5bOtv9jqNsd3hT+kY8pHt6VkAQ==
+"@gemeente-denhaag/timeline@^0.2.3-alpha.21":
+  version "0.2.3-alpha.21"
+  resolved "https://registry.yarnpkg.com/@gemeente-denhaag/timeline/-/timeline-0.2.3-alpha.21.tgz#36db8c083a00d83918073611ca93fea0b8429370"
+  integrity sha512-hPjnAJCdbk/aDG3u5R7dNPalnS8mSZCmZEaguIWZAAqvK7mbmpcbCSNCDptgoE/37USa6ntaGNWkCoolqymc8Q==
   dependencies:
-    "@gemeente-denhaag/baseprops" "^0.2.3-alpha.7"
-    "@gemeente-denhaag/icons" "^0.2.3-alpha.7"
-    "@gemeente-denhaag/typography" "^0.2.3-alpha.7"
-    "@material-ui/core" "^4.11.0"
-    clsx "^1.1.1"
-
-"@gemeente-denhaag/toolbar@^0.2.3-alpha.7":
-  version "0.2.3-alpha.7"
-  resolved "https://registry.yarnpkg.com/@gemeente-denhaag/toolbar/-/toolbar-0.2.3-alpha.7.tgz#8b8b0e3f17aff1c0d723b617cee2057810ac62f8"
-  integrity sha512-9XYY6GhzPPQNnaiIwOVxiva7evY8dv8aCB/pFwvt43w/0FLD7nEJTPoyBbUDJU94qQioubdXLaMC1c2BIkOymw==
-  dependencies:
-    "@gemeente-denhaag/baseprops" "^0.2.3-alpha.7"
+    "@gemeente-denhaag/baseprops" "^0.2.3-alpha.21"
+    "@gemeente-denhaag/icons" "^0.2.3-alpha.21"
+    "@gemeente-denhaag/typography" "^0.2.3-alpha.21"
     "@material-ui/core" "^4.11.0"
 
-"@gemeente-denhaag/typography@^0.2.3-alpha.7":
-  version "0.2.3-alpha.7"
-  resolved "https://registry.yarnpkg.com/@gemeente-denhaag/typography/-/typography-0.2.3-alpha.7.tgz#4b3cc9f39d8d548ceceed88f838a5b19fef27e88"
-  integrity sha512-knrkYXGalE9Z/MhWeEw8kMyqrK/t/9IOYfjKvkfebINJhBiSira4RAHqM2zBaLPKFbglRV2DqKtoUFbhmwK9kQ==
+"@gemeente-denhaag/toolbar@^0.2.3-alpha.21":
+  version "0.2.3-alpha.21"
+  resolved "https://registry.yarnpkg.com/@gemeente-denhaag/toolbar/-/toolbar-0.2.3-alpha.21.tgz#54e27ca6f76ffd7edd2fc62f08481a0dff68b2b5"
+  integrity sha512-mxPzFGyOkZjEXR4AZbgoTDaI6fTavMxxXfeSpIG+kO9YKjIoy2kMWEvTF5H/wZL3g1h4HQiKR6QMsxgiIMXtSA==
   dependencies:
-    "@gemeente-denhaag/basedatadisplayprops" "^0.2.3-alpha.7"
+    "@gemeente-denhaag/baseprops" "^0.2.3-alpha.21"
+    "@material-ui/core" "^4.11.0"
+
+"@gemeente-denhaag/typography@^0.2.3-alpha.21":
+  version "0.2.3-alpha.21"
+  resolved "https://registry.yarnpkg.com/@gemeente-denhaag/typography/-/typography-0.2.3-alpha.21.tgz#962bec717f52b23cda2578361266d0c0c456a710"
+  integrity sha512-BpGY1sjgyr+IQB6PRTeKxXnbY+PS7G6Lpi6eD6Ajm3jDbyMCJJMkuwyqs9R7zTAKI1fU/jOqlokhMbHMk9LQlg==
+  dependencies:
+    "@gemeente-denhaag/basedatadisplayprops" "^0.2.3-alpha.21"
 
 "@hapi/address@2.x.x":
   version "2.1.4"
@@ -5523,7 +5521,7 @@ clone@^1.0.2:
   resolved "https://registry.yarnpkg.com/clone/-/clone-1.0.4.tgz#da309cc263df15994c688ca902179ca3c7cd7c7e"
   integrity sha1-2jCcwmPfFZlMaIypAheco8fNfH4=
 
-clsx@^1.0.2, clsx@^1.0.4, clsx@^1.1.1:
+clsx@^1.0.2, clsx@^1.0.4:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/clsx/-/clsx-1.1.1.tgz#98b3134f9abbdf23b2663491ace13c5c03a73188"
   integrity sha512-6/bPho624p3S2pMyvP5kKBPXnI3ufHLObBFCfgx+LkeR5lg2XYy2hqZqUf45ypD8COn2bhgGJSUE+l5dhNBieA==


### PR DESCRIPTION
Adds route to page for single case, but clicking on case in overview does not lead here yet, since the card component needs adjustments to support react-router-dom. Completed cases are not yet display in gray, and the tabs component still has the default material ui look. These features will be adjusted once the component library supports them.  Closes https://ritense.tpondemand.com/entity/30878-portal-lopende-zaken.