### PR TITLE
#32564 email value shouldnt be 'undefined'

### DIFF
--- a/packages/user-interface/src/components/detail-list/detail-list.tsx
+++ b/packages/user-interface/src/components/detail-list/detail-list.tsx
@@ -45,7 +45,7 @@ const DetailList: FC<DetailListProps> = ({details}) => {
             </span>
             {detail.showEditButton && (
               <Link
-                onClick={() => setUserInformation(detail.translationKey, `${detail.value}`)}
+                onClick={() => setUserInformation(detail.translationKey, detail.value)}
                 component={RouterLink}
                 to={`/account/aanpassen?prop=${detail.translationKey}`}
                 hrefLang={hrefLang}

--- a/packages/user-interface/src/contexts/user-information-context.ts
+++ b/packages/user-interface/src/contexts/user-information-context.ts
@@ -2,7 +2,7 @@ import * as React from 'react';
 
 interface UserInformationContextInterface {
   userInformation: {[key: string]: string};
-  setUserInformation: (key: string, value: string) => void;
+  setUserInformation: (key: string, value: string | false | undefined | null) => void;
 }
 
 export const UserInformationContext = React.createContext<UserInformationContextInterface>(

--- a/packages/user-interface/src/pages/edit-account/edit-account-page.tsx
+++ b/packages/user-interface/src/pages/edit-account/edit-account-page.tsx
@@ -68,8 +68,8 @@ const EditAccountPage = () => {
           label={propTranslation}
           className={styles['edit-account__text-field']}
           defaultValue={defaultValue || ''}
-          error={!valid}
-          helperText={!valid ? errorTranslation : ''}
+          error={!valid && `${value}`.length >= 1}
+          helperText={!valid && `${value}`.length >= 1 ? errorTranslation : ''}
           disabled={loading}
         />
       </div>


### PR DESCRIPTION
- Fix: When no email was provided, the text field displayed the text 'undefined' while it should be empty
- Fix: Error text shouldn't be visible when the text field is empty