### PR TITLE
Added some extra logic to keycloak wrapper, so the portal can be DigiD compliant. (Logout after being idle for 15 minutes.)

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -4,6 +4,9 @@
     "es2021": true,
     "jest": true
   },
+  "globals": {
+    "NodeJS": true
+  },
   "extends": ["plugin:react/recommended", "plugin:prettier/recommended", "airbnb", "prettier"],
   "parser": "@typescript-eslint/parser",
   "parserOptions": {

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -4,9 +4,6 @@
     "es2021": true,
     "jest": true
   },
-  "globals": {
-    "NodeJS": true
-  },
   "extends": ["plugin:react/recommended", "plugin:prettier/recommended", "airbnb", "prettier"],
   "parser": "@typescript-eslint/parser",
   "parserOptions": {

--- a/packages/authentication/src/components/keycloak-wrapper/keycloak-wrapper.tsx
+++ b/packages/authentication/src/components/keycloak-wrapper/keycloak-wrapper.tsx
@@ -37,7 +37,7 @@ const KeycloakProvider: FC<KeycloakWrapperProps> = ({
   redirectUri,
   autoRefreshToken = false,
   idleTimeoutMinutes = 15,
-  minValiditySeconds = 30
+  minValiditySeconds = 30,
 }) => {
   const {setKeycloakToken, setDecodedToken} = useContext(KeycloakContext);
   const [authClient] = useState(

--- a/packages/authentication/src/components/keycloak-wrapper/keycloak-wrapper.tsx
+++ b/packages/authentication/src/components/keycloak-wrapper/keycloak-wrapper.tsx
@@ -30,7 +30,7 @@ const BASIC_ACTIVITY_EVENTS: string[] = [
 ];
 
 const IdleTimer: FC<IdleTimerProps> = ({idleTimeoutMinutes, onTimerReset}) => {
-  let timeout: NodeJS.Timeout | null = null;
+  let timeout: ReturnType<typeof setTimeout> | null = null;
 
   const resetTimer = () => {
     onTimerReset(); // Updates the accesstoken if necessary

--- a/packages/authentication/src/components/keycloak-wrapper/keycloak-wrapper.tsx
+++ b/packages/authentication/src/components/keycloak-wrapper/keycloak-wrapper.tsx
@@ -10,6 +10,7 @@ import {DecodedToken} from '../../interfaces';
 interface KeycloakWrapperProps extends KeycloakConfig {
   redirectUri: string;
   autoRefreshToken?: boolean;
+  autoIdleSessionLogout?: boolean;
   idleTimeoutMinutes?: number;
   minValiditySeconds?: number;
 }
@@ -71,6 +72,7 @@ const KeycloakProvider: FC<KeycloakWrapperProps> = ({
   realm,
   redirectUri,
   autoRefreshToken = false,
+  autoIdleSessionLogout = true,
   idleTimeoutMinutes = 15,
   minValiditySeconds = 30,
 }) => {
@@ -111,7 +113,9 @@ const KeycloakProvider: FC<KeycloakWrapperProps> = ({
         }
       }}
     >
-      <IdleTimer onTimerReset={updateToken} idleTimeoutMinutes={idleTimeoutMinutes} />
+      {autoIdleSessionLogout && (
+        <IdleTimer onTimerReset={updateToken} idleTimeoutMinutes={idleTimeoutMinutes} />
+      )}
       {children}
     </ReactKeycloakProvider>
   );

--- a/packages/authentication/src/components/keycloak-wrapper/keycloak-wrapper.tsx
+++ b/packages/authentication/src/components/keycloak-wrapper/keycloak-wrapper.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import {ReactKeycloakProvider} from '@react-keycloak/web';
-import Keycloak, {KeycloakConfig, KeycloakInitOptions} from 'keycloak-js';
-import {FC, Fragment, useContext, useState} from 'react';
+import Keycloak, {KeycloakConfig, KeycloakInitOptions, KeycloakInstance} from 'keycloak-js';
+import {FC, Fragment, useContext, useState, useEffect} from 'react';
 import jwtDecode from 'jwt-decode';
 import {formatUrlTrailingSlash} from '../../utils';
 import {KeycloakContext} from '../../contexts';
@@ -10,7 +10,24 @@ import {DecodedToken} from '../../interfaces';
 interface KeycloakWrapperProps extends KeycloakConfig {
   redirectUri: string;
   autoRefreshToken?: boolean;
+  idleTimeoutMinutes?: number;
+  minValiditySeconds?: number;
 }
+
+interface IdleTimerProps {
+  idleTimeoutMinutes: number;
+  onTimerReset: () => void;
+}
+
+const BASIC_ACTIVITY_EVENTS: string[] = [
+  'mousedown',
+  'keydown',
+  'pointerdown',
+  'touchstart',
+  'scroll',
+  'wheel',
+  'audiostart',
+];
 
 const KeycloakProvider: FC<KeycloakWrapperProps> = ({
   children,
@@ -18,11 +35,18 @@ const KeycloakProvider: FC<KeycloakWrapperProps> = ({
   clientId,
   realm,
   redirectUri,
-  autoRefreshToken = true,
+  autoRefreshToken = false,
+  idleTimeoutMinutes = 15,
+  minValiditySeconds = 30
 }) => {
   const {setKeycloakToken, setDecodedToken} = useContext(KeycloakContext);
   const [authClient] = useState(
-    () => new (Keycloak as any)({url: formatUrlTrailingSlash(`${url}`, false), clientId, realm})
+    () =>
+      new (Keycloak as any)({
+        url: formatUrlTrailingSlash(`${url}`, false),
+        clientId,
+        realm,
+      }) as KeycloakInstance
   );
   const initOptions: KeycloakInitOptions = {
     checkLoginIframe: false,
@@ -31,6 +55,10 @@ const KeycloakProvider: FC<KeycloakWrapperProps> = ({
     redirectUri: formatUrlTrailingSlash(redirectUri, false),
   };
   const decodeToken = (jwtToken: string) => jwtDecode<DecodedToken>(jwtToken);
+
+  const updateToken = () => {
+    authClient.updateToken(minValiditySeconds);
+  };
 
   return (
     <ReactKeycloakProvider
@@ -42,7 +70,13 @@ const KeycloakProvider: FC<KeycloakWrapperProps> = ({
         setKeycloakToken(token || '');
         if (token) setDecodedToken(decodeToken(token));
       }}
+      onEvent={eventType => {
+        if (eventType === 'onAuthRefreshError') {
+          authClient.logout();
+        }
+      }}
     >
+      <IdleTimer onTimerReset={updateToken} idleTimeoutMinutes={idleTimeoutMinutes} />
       {children}
     </ReactKeycloakProvider>
   );
@@ -73,6 +107,41 @@ const KeycloakWrapper: FC<KeycloakWrapperProps> = props => {
       <KeycloakProvider {...props} />
     </KeycloakContext.Provider>
   );
+};
+
+const IdleTimer: FC<IdleTimerProps> = ({idleTimeoutMinutes, onTimerReset}) => {
+  let timeout: NodeJS.Timeout | null = null;
+
+  const resetTimer = () => {
+    onTimerReset(); // Updates the accesstoken if necessary
+    if (timeout) {
+      clearTimeout(timeout);
+    }
+    timeout = setTimeout(() => {
+      window.location.reload(); // Refresh to check with Keycloak if session is still valid
+    }, 1000 * 60 * idleTimeoutMinutes); // Should be 15 minutes to comply with DigiD requirements: SSO session idle + 2 minute (internal Keycloak buffer time).
+  };
+
+  useEffect(() => {
+    // initiate timeout
+    resetTimer();
+
+    // listen for activity events
+    BASIC_ACTIVITY_EVENTS.forEach(eventType => {
+      window.addEventListener(eventType, resetTimer);
+    });
+
+    // cleanup
+    return () => {
+      if (timeout) {
+        clearTimeout(timeout);
+        BASIC_ACTIVITY_EVENTS.forEach(eventType => {
+          window.removeEventListener(eventType, resetTimer);
+        });
+      }
+    };
+  }, []);
+  return <React.Fragment />;
 };
 
 export {KeycloakWrapper};


### PR DESCRIPTION
In the current situation, the nl-portal-libraries cannot comply to the DigiD requirements, because you will not be logged out automatically after being idle for 15 minutes. In fact, the current autoRefreshToken setting results in an almost infinite session. This change will fix that, and makes it possible to be DigiD compliant combined with the right Keycloak configuration.